### PR TITLE
Add the system call outputDebugString.

### DIFF
--- a/libctru/include/3ds/svc.h
+++ b/libctru/include/3ds/svc.h
@@ -48,5 +48,6 @@ s32  svcGetProcessInfo(s64* out, Handle process, u32 type);
 s32  svcConnectToPort(volatile Handle* out, const char* portName);
 s32  svcSendSyncRequest(Handle session);
 s32  svcGetProcessId(u32 *out, Handle handle);
+s32  svcOutputDebugString(const char* str, int length);
 
 #endif

--- a/libctru/source/svc.s
+++ b/libctru/source/svc.s
@@ -195,3 +195,13 @@ svcGetProcessId:
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx lr
+
+.global svcOutputDebugString
+.type svcOutputDebugString, %function
+svcOutputDebugString:
+   str r0, [sp,#-0x4]!
+   svc 0x3D
+   ldr r2, [sp], #4
+   str r1, [r2]
+   bx lr
+


### PR DESCRIPTION
This doesn't do anything on retail consoles, but homebrew developers can use it to debug applications in Citra or in other 3DS emulators which HLE this system call.

Addresses #9.

My implementation works with what we have in Citra (i.e. I can call this in a homebrew application and the string is printed when running it in Citra), but actually I really have no idea what I've done there...
