### PR TITLE
Set GPU example's make file to explicitly use python3 and fix aemstro enviroment variable

### DIFF
--- a/examples/gpu/Makefile
+++ b/examples/gpu/Makefile
@@ -161,7 +161,7 @@ $(OUTPUT).elf	:	$(OFILES)
 %.vsh.o	:	%.vsh
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
-	@python $(AEMSTRO)/aemstro_as.py $< ../$(notdir $<).shbin
+	@python3 $(AEMSTROPATH)/aemstro_as.py $< ../$(notdir $<).shbin
 	@bin2s ../$(notdir $<).shbin | $(PREFIX)as -o $@
 	@echo "extern const u8" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(notdir $<).shbin | tr . _)`.h
 	@echo "extern const u8" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(notdir $<).shbin | tr . _)`.h


### PR DESCRIPTION
Before, the make file would use the system default python, aemstro only work with python3 so explicitly calling python3 in the make file will help avoid confusion.

Changed aemstro's path enviroment variable from AEMSTRO to AEMSTROPATH because the readme file defines it as AEMSTROPATH and I believe AEMSTROPATH is more descriptive