### PR TITLE
added svcCloseHandle to FSDIR_Close()

### DIFF
--- a/libctru/source/services/fs.c
+++ b/libctru/source/services/fs.c
@@ -1331,6 +1331,7 @@ FSDIR_Close(Handle handle)
 	Result ret = 0;
 	if((ret = svcSendSyncRequest(handle)))
 		return ret;
-
-	return cmdbuf[1];
+	ret = cmdbuf[1];
+	if(!ret)ret = svcCloseHandle(handle);
+	return ret;
 }


### PR DESCRIPTION
FSDIR_Close() and FSFILE_Close() should have the same behavior
