### PR TITLE
Fix copy/paste error in FSFILE_Write documentation

### DIFF
--- a/libctru/source/services/fs.c
+++ b/libctru/source/services/fs.c
@@ -1000,7 +1000,7 @@ FSFILE_Read(Handle handle,
 /*! Write data to an open file
  *
  *  @param[in]  handle       Open file handle
- *  @param[out] bytesWritten Number of bytes read
+ *  @param[out] bytesWritten Number of bytes written
  *  @param[in]  offset       File offset to write to
  *  @param[in]  buffer       Buffer to write from
  *  @param[in]  size         Number of bytes to write


### PR DESCRIPTION
This pull request fixes a copy/paste error where FSFILE_Write was documented as having an out argument that was the number of bytes read, as opposed to written.
