### PR TITLE
Add missing include for gfxScreen_t in console.h

### DIFF
--- a/libctru/include/3ds/console.h
+++ b/libctru/include/3ds/console.h
@@ -18,6 +18,7 @@ consoleInit()
 #define CONSOLE_H
 
 #include <3ds/types.h>
+#include <3ds/gfx.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This include is required when the entire 3ds.h isn’t included in a translation unit.