### PR TITLE
Add AM_GetTitleProductCode, FSUSER_GetNandArchiveResource, and fix missing service imports in 3ds.h.

### DIFF
--- a/libctru/include/3ds.h
+++ b/libctru/include/3ds.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <3ds/console.h>
 
 #include <3ds/services/ac.h>
+#include <3ds/services/am.h>
 #include <3ds/services/apt.h>
 #include <3ds/services/cfgnor.h>
 #include <3ds/services/cfgu.h>
@@ -25,6 +26,9 @@ extern "C" {
 #include <3ds/services/irrst.h>
 #include <3ds/services/httpc.h>
 #include <3ds/services/ir.h>
+#include <3ds/services/ns.h>
+#include <3ds/services/pm.h>
+#include <3ds/services/ps.h>
 #include <3ds/services/ptm.h>
 #include <3ds/services/soc.h>
 #include <3ds/services/mic.h>

--- a/libctru/include/3ds/services/am.h
+++ b/libctru/include/3ds/services/am.h
@@ -91,3 +91,13 @@ Note: The title must have the uniqueid: 0x00000, otherwise this will fail.
   titleid		title id of title
 */
 Result AM_InstallFIRM(u8 mediatype, u64 titleid);
+
+/* AM_GetTitleProductCode()
+About: Gets the product code of a title based on its title id.
+
+  mediatype		mediatype of title
+  titleid		title id of title
+  productcode           buffer to output the product code to (should have a length of 16) 
+*/
+Result AM_GetTitleProductCode(u8 mediatype, u64 titleid, char* productcode);
+

--- a/libctru/include/3ds/services/fs.h
+++ b/libctru/include/3ds/services/fs.h
@@ -145,6 +145,7 @@ Result FSUSER_DeleteDirectory(Handle *handle, FS_archive archive, FS_path dirLow
 Result FSUSER_RenameFile(Handle *handle, FS_archive srcArchive, FS_path srcFileLowPath, FS_archive destArchive, FS_path destFileLowPath);
 Result FSUSER_RenameDirectory(Handle *handle, FS_archive srcArchive, FS_path srcDirLowPath, FS_archive destArchive, FS_path destDirLowPath);
 Result FSUSER_GetSdmcArchiveResource(Handle *handle, u32 *sectorSize, u32 *clusterSize, u32 *numClusters, u32 *freeClusters);
+Result FSUSER_GetNandArchiveResource(Handle *handle, u32 *sectorSize, u32 *clusterSize, u32 *numClusters, u32 *freeClusters);
 Result FSUSER_IsSdmcDetected(Handle *handle, u8 *detected);
 Result FSUSER_IsSdmcWritable(Handle *handle, u8 *writable);
 

--- a/libctru/source/services/am.c
+++ b/libctru/source/services/am.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <3ds/types.h>
 #include <3ds/svc.h>
@@ -163,5 +164,21 @@ Result AM_InstallFIRM(u8 mediatype, u64 titleid)
 
 	if((ret = svcSendSyncRequest(amHandle))!=0) return ret;
 
+	return (Result)cmdbuf[1];
+}
+
+Result AM_GetTitleProductCode(u8 mediatype, u64 titleid, char* productcode)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+	
+	cmdbuf[0] = 0x000500C0;
+	cmdbuf[1] = mediatype;
+	cmdbuf[2] = titleid & 0xffffffff;
+	cmdbuf[3] = (titleid >> 32) & 0xffffffff;
+	
+	if((ret = svcSendSyncRequest(amHandle))!=0) return ret;
+
+	snprintf(productcode, 16, "%s", (char*)(&cmdbuf[2]));
 	return (Result)cmdbuf[1];
 }

--- a/libctru/source/services/fs.c
+++ b/libctru/source/services/fs.c
@@ -887,6 +887,68 @@ FSUSER_GetSdmcArchiveResource(Handle *handle,
 	return cmdbuf[1];
 }
 
+/*! Get NAND information
+ *
+ *  @param[in]  handle       fs:USER handle
+ *  @param[out] sectorSize   Sector size (bytes)
+ *  @param[out] clusterSize  Cluster size (bytes)
+ *  @param[out] numClusters  Total number of clusters
+ *  @param[out] freeClusters Number of free clusters
+ *
+ *  @returns error
+ *
+ *  @internal
+ *
+ *  #### Request
+ *
+ *  Index Word | Description
+ *  -----------|-------------------------
+ *  0          | Header code [0x08140000]
+ *
+ *  #### Response
+ *
+ *  Index Word | Description
+ *  -----------|-------------------------
+ *  0          | Header code
+ *  1          | Result code
+ *  2          | Sector (bytes)
+ *  3          | Cluster (bytes)
+ *  4          | Partition capacity (clusters)
+ *  5          | Free space (clusters)
+ */
+Result
+FSUSER_GetNandArchiveResource(Handle *handle,
+                              u32    *sectorSize,
+                              u32    *clusterSize,
+                              u32    *numClusters,
+                              u32    *freeClusters)
+{
+	if(!handle)
+		handle = &fsuHandle;
+
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = 0x08150000;
+
+	Result ret = 0;
+	if((ret = svcSendSyncRequest(*handle)))
+		return ret;
+
+	if(sectorSize)
+		*sectorSize = cmdbuf[2];
+
+	if(clusterSize)
+		*clusterSize = cmdbuf[3];
+
+	if(numClusters)
+		*numClusters = cmdbuf[4];
+
+	if(freeClusters)
+		*freeClusters = cmdbuf[5];
+
+	return cmdbuf[1];
+}
+
 /*! Check if SD card is detected
  *
  *  @param[in]  handle   fs:USER handle


### PR DESCRIPTION
Adds AM_GetTitleProductCode to the am services and FSUSER_GetNandArchiveResource to the fs services.

Also adds missing service header includes to 3ds.h.