### PR TITLE
Improve shader support

### DIFF
--- a/libctru/include/3ds/gpu/gpu.h
+++ b/libctru/include/3ds/gpu/gpu.h
@@ -190,6 +190,8 @@ typedef enum{
 }GPU_Primitive_t;
 
 void GPU_SetUniform(u32 startreg, u32* data, u32 numreg);
+void GPU_SetIntUniform(u32 startreg, u32 value);
+void GPU_SetBoolUniforms(u32 values);
 
 void GPU_SetViewport(u32* depthBuffer, u32* colorBuffer, u32 x, u32 y, u32 w, u32 h);
 

--- a/libctru/include/3ds/gpu/shdr.h
+++ b/libctru/include/3ds/gpu/shdr.h
@@ -28,7 +28,8 @@ typedef struct{
 typedef struct{
 	u16 type;
 	u16 regID;
-	u32 header;
+	u8 compMask;
+	u8 pad[3];
 }DVLE_outEntry_s;
 
 typedef struct{

--- a/libctru/source/gpu/gpu.c
+++ b/libctru/source/gpu/gpu.c
@@ -234,6 +234,16 @@ void GPU_SetUniform(u32 startreg, u32* data, u32 numreg)
 	GPUCMD_Add(0x000F02C1, data, numreg*4);
 }
 
+void GPU_SetIntUniform(u32 reg, u32 value)
+{
+	GPUCMD_AddSingleParam(0x000F02B1 + reg, value);
+}
+
+void GPU_SetBoolUniforms(u32 values)
+{
+	GPUCMD_AddSingleParam(0x000F02B0, values);
+}
+
 //TODO : fix
 u32 f32tof24(float f)
 {

--- a/libctru/source/gpu/shdr.c
+++ b/libctru/source/gpu/shdr.c
@@ -57,7 +57,7 @@ DVLB_s* SHDR_ParseSHBIN(u32* shbinData, u32 shbinSize)
 		return ret;
 }
 
-s8 SHDR_GetUniformRegister(DVLB_s* dvlb, const char* name, u8 programID)
+static s32 SHDR_GetUniformRegisterInternal(DVLB_s* dvlb, const char* name, u8 programID)
 {
 	if(!dvlb || !name)return -1;
 
@@ -66,10 +66,33 @@ s8 SHDR_GetUniformRegister(DVLB_s* dvlb, const char* name, u8 programID)
 	int i;	DVLE_uniformEntry_s* u=dvle->uniformTableData;
 	for(i=0;i<dvle->uniformTableSize;i++)
 	{
-		if(!strcmp(&dvle->symbolTableData[u->symbolOffset],name))return (s8)u->startReg-0x10;
+		if(!strcmp(&dvle->symbolTableData[u->symbolOffset],name))
+			return u->startReg;
+
 		u++;
 	}
 	return -1;
+}
+
+s8 SHDR_GetUniformRegister(DVLB_s* dvlb, const char* name, u8 programID)
+{
+	s32 value = SHDR_GetUniformRegisterInternal(dvlb, name, programID);
+	if (value < 0x10 || value > 0x6f) return -1;
+	else return value - 0x10;
+}
+
+s8 SHDR_GetIntUniformRegster(DVLB_s* dvlb, const char* name, u8 programID)
+{
+	s32 value = SHDR_GetUniformRegisterInternal(dvlb, name, programID);
+	if (value < 0x70 || value > 0x73) return -1;
+	else return value - 0x70;
+}
+
+s8 SHDR_GetBoolUniformRegster(DVLB_s* dvlb, const char* name, u8 programID)
+{
+	s32 value = SHDR_GetUniformRegisterInternal(dvlb, name, programID);
+	if (value < 0x78 || value > 0x87) return -1;
+	else return value - 0x78;
 }
 
 void DVLP_SendCode(DVLP_s* dvlp)
@@ -101,7 +124,7 @@ void DVLP_SendOpDesc(DVLP_s* dvlp)
 
 void DVLE_SendOutmap(DVLE_s* dvle)
 {
-	if(!dvle)return;
+	if(!dvle) return;
 
 	u32 param[0x7]={0x1F1F1F1F,0x1F1F1F1F,0x1F1F1F1F,0x1F1F1F1F,
 					0x1F1F1F1F,0x1F1F1F1F,0x1F1F1F1F};


### PR DESCRIPTION
* output attribute component masks are considered now
* boolean and integer uniforms can be set now

I didn't rename existing functions to be consistent because that would break backwards compatibilty. I'll leave it up to someone else to rename them, hence.