### PR TITLE
Replaced AM_installFIRM() with AM_installNativeFirm().

### DIFF
--- a/libctru/include/3ds/services/am.h
+++ b/libctru/include/3ds/services/am.h
@@ -103,13 +103,10 @@ Note: If the title has the system category bit set, this will fail
 */
 Result AM_DeleteAppTitle(u8 mediatype, u64 titleID);
 
-/* AM_InstallFIRM()
-About: Installs FIRM to NAND (firm0:/ & firm1:/) from a CXI
-Note: The title must have the uniqueid: 0x00000, otherwise this will fail.
-
-  titleid		title id of title
+/* AM_InstallNativeFirm()
+About: Installs NATIVE_FIRM to NAND (firm0:/ & firm1:/) from a CXI
 */
-Result AM_InstallFIRM(u64 titleID);
+Result AM_InstallNativeFirm();
 
 /* AM_GetTitleProductCode()
 About: Gets the product code of a title based on its title id.

--- a/libctru/source/services/am.c
+++ b/libctru/source/services/am.c
@@ -171,14 +171,12 @@ Result AM_DeleteAppTitle(u8 mediatype, u64 titleID)
 	return (Result)cmdbuf[1];
 }
 
-Result AM_InstallFIRM(u64 titleID)
+Result AM_InstallNativeFirm()
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 
-	cmdbuf[0] = 0x04010080;
-	cmdbuf[1] = titleID & 0xffffffff;
-	cmdbuf[2] = (u32)(titleID >> 32);
+	cmdbuf[0] = 0x040F0000;
 
 	if((ret = svcSendSyncRequest(amHandle))!=0) return ret;
 


### PR DESCRIPTION
AM_installFIRM() only allowed NATIVE_FIRM anyway so why not let AM load the TID for us? Saves code for New 3DS checks.