### PR TITLE
Reset GPUCMD buffer after running GPU_Reset commands.

### DIFF
--- a/libctru/source/gpu/gpu.c
+++ b/libctru/source/gpu/gpu.c
@@ -216,6 +216,7 @@ void GPU_Reset(u32* gxbuf, u32* gpuBuf, u32 gpuBufSize)
 
 	GPUCMD_Finalize();
 	GPUCMD_Run(gpuBuf);
+	GPUCMD_SetBufferOffset(0);
 }
 
 void GPU_SetFloatUniform(GPU_SHADER_TYPE type, u32 startreg, u32* data, u32 numreg)


### PR DESCRIPTION
GPU_Reset makes various GPU buffer writes, however it doesn't set the buffer offset back to 0 after flushing and running. Because of this, the GPU example would freeze on a black screen for some people. Setting the buffer offset to 0 at the end of GPU_Reset fixes this issue.

Why this issue only occurred for some people, I don't quite know. However, I have tested this fix and can confirm that it works.