### PR TITLE
Remove MEMOP_FREE_LINEAR

### DIFF
--- a/libctru/include/3ds/svc.h
+++ b/libctru/include/3ds/svc.h
@@ -11,7 +11,6 @@ typedef enum {
 	MEMOP_UNMAP=5, // Mirror unmapping
 	MEMOP_PROT =6, // Change protection
 
-	MEMOP_FREE_LINEAR =0x10001, // Free linear heap
 	MEMOP_ALLOC_LINEAR=0x10003  // Allocate linear heap
 } MemOp;
 


### PR DESCRIPTION
MEMOP_FREE_LINEAR does not actually exist, and beyond 4.x it causes svcControlMemory to fail since the [svcControlMemory parameter checks](http://3dbrew.org/wiki/3DS_System_Flaws#Kernel11) flaw was fixed. MEMOP_FREE works just fine.