### PR TITLE
fix warning types not matching

### DIFF
--- a/libctru/source/gpu/gpu.c
+++ b/libctru/source/gpu/gpu.c
@@ -54,12 +54,12 @@ void GPUCMD_Run(u32* gxbuf)
 }
 
 extern u32 __linear_heap_size;
-extern u32* __linear_heap;
+extern u32 __linear_heap;
 
 void GPUCMD_FlushAndRun(u32* gxbuf)
 {
 	//take advantage of GX_SetCommandList_First to flush gsp heap
-	GX_SetCommandList_First(gxbuf, gpuCmdBuf, gpuCmdBufOffset*4, __linear_heap, __linear_heap_size, NULL, 0);
+	GX_SetCommandList_First(gxbuf, gpuCmdBuf, gpuCmdBufOffset*4, (u32 *) __linear_heap, __linear_heap_size, NULL, 0);
 	GX_SetCommandList_Last(gxbuf, gpuCmdBuf, gpuCmdBufOffset*4, 0x0);
 }
 

--- a/libctru/source/system/allocateHeaps.c
+++ b/libctru/source/system/allocateHeaps.c
@@ -13,10 +13,10 @@ void __attribute__((weak)) __system_allocateHeaps() {
 
 	// Allocate the application heap
 	__heapBase = 0x08000000;
-	svcControlMemory(&tmp, __heapBase, 0x0, __heap_size, MEMOP_ALLOC, 0x3);
+	svcControlMemory(&tmp, __heapBase, 0x0, __heap_size, MEMOP_ALLOC, MEMPERM_READ | MEMPERM_WRITE);
 
 	// Allocate the linear heap
-	svcControlMemory(&__linear_heap, 0x0, 0x0, __linear_heap_size, MEMOP_ALLOC_LINEAR, 0x3);
+	svcControlMemory(&__linear_heap, 0x0, 0x0, __linear_heap_size, MEMOP_ALLOC_LINEAR, MEMPERM_READ | MEMPERM_WRITE);
 	// Set up newlib heap
 	fake_heap_start = (char*)__heapBase;
 	fake_heap_end = fake_heap_start + __heap_size;


### PR DESCRIPTION
__linear_heap is used at some places but declared with 

    extern u32 * __linear_heap;

That would trigger the following warning : 

    gpu.c:57: warning: type of "__linear_heap" does not match original declaration ... allocateHeaps.c:6: note: previously declared here"