### PR TITLE
Fix gpu example Makefiles for latest picasso

### DIFF
--- a/examples/graphics/gpu/Makefile
+++ b/examples/graphics/gpu/Makefile
@@ -1,0 +1,7 @@
+SUBDIRS:= `ls | egrep -v '^(CVS)$$'`
+all:
+	@for i in $(SUBDIRS); do if test -e $$i/Makefile ; then $(MAKE) -C $$i || { exit 1;} fi; done;
+clean:
+	@for i in $(SUBDIRS); do if test -e $$i/Makefile ; then $(MAKE)  -C $$i clean || { exit 1;} fi; done;
+install:
+	@for i in $(SUBDIRS); do if test -e $$i/Makefile ; then $(MAKE)  -C $$i install || { exit 1;} fi; done;

--- a/examples/graphics/gpu/geoshader/Makefile
+++ b/examples/graphics/gpu/geoshader/Makefile
@@ -164,7 +164,7 @@ $(OUTPUT).elf	:	$(OFILES)
 	@echo $(notdir $<)
 	$(eval CURBIN := $(patsubst %.pica,%.shbin,$(notdir $<)))
 	$(eval CURH := $(patsubst %.pica,%.psh.h,$(notdir $<)))
-	@picasso $(CURBIN) $< $(CURH)
+	@picasso -h $(CURH) -o $(CURBIN) $<
 	@bin2s $(CURBIN) | $(AS) -o $@
 	@echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(CURBIN) | tr . _)`.h
 	@echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(CURBIN) | tr . _)`.h

--- a/examples/graphics/gpu/simple_tri/Makefile
+++ b/examples/graphics/gpu/simple_tri/Makefile
@@ -164,7 +164,7 @@ $(OUTPUT).elf	:	$(OFILES)
 	@echo $(notdir $<)
 	$(eval CURBIN := $(patsubst %.pica,%.shbin,$(notdir $<)))
 	$(eval CURH := $(patsubst %.pica,%.psh.h,$(notdir $<)))
-	@picasso $(CURBIN) $< $(CURH)
+	@picasso -h $(CURH) -o $(CURBIN) $<
 	@bin2s $(CURBIN) | $(AS) -o $@
 	@echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(CURBIN) | tr . _)`.h
 	@echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(CURBIN) | tr . _)`.h

--- a/examples/graphics/gpu/textured_cube/Makefile
+++ b/examples/graphics/gpu/textured_cube/Makefile
@@ -164,7 +164,7 @@ $(OUTPUT).elf	:	$(OFILES)
 	@echo $(notdir $<)
 	$(eval CURBIN := $(patsubst %.pica,%.shbin,$(notdir $<)))
 	$(eval CURH := $(patsubst %.pica,%.psh.h,$(notdir $<)))
-	@picasso $(CURBIN) $< $(CURH)
+	@picasso -h $(CURH) -o $(CURBIN) $<
 	@bin2s $(CURBIN) | $(AS) -o $@
 	@echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(CURBIN) | tr . _)`.h
 	@echo "extern const u8" `(echo $(CURBIN) | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(CURBIN) | tr . _)`.h


### PR DESCRIPTION
A recent commit to picasso changed the parameter format to `picasso -h [header] -o [output] [input]`

Also added a Makefile to graphics/gpu so it gets included in the parent Makefiles.