### PR TITLE
Fix the install rule in libctru’s the Makefile

### DIFF
--- a/libctru/Makefile
+++ b/libctru/Makefile
@@ -111,9 +111,9 @@ dist-src:
 
 dist: dist-src dist-bin
 
-install: dist-bin
-	mkdir -p $(DEVKITPRO)/libctru
-	bzip2 -cd libctru-$(VERSION).tar.bz2 | tar -x -C $(DEVKITPRO)/libctru
+install:
+	@mkdir -p $(DESTDIR)$(DEVKITPRO)/libctru
+	@cp -r include lib default_icon.png $(DESTDIR)$(DEVKITPRO)/libctru
 
 dox:
 	@doxygen Doxyfile


### PR DESCRIPTION
The current way was depending on tar and bzip2 to first create a binary
package then extract it in the directory pointed by DEVKITPRO.

This commit makes the install rule only copy the relevant files, and
handle correctly the standard DESTDIR variable, so packagers can use it
to make their own packages.