### PR TITLE
Fix building on FreeBSD

### DIFF
--- a/libctru/Makefile
+++ b/libctru/Makefile
@@ -113,7 +113,7 @@ dist: dist-src dist-bin
 
 install: dist-bin
 	mkdir -p $(DEVKITPRO)/libctru
-	bzip2 -cd libctru-$(VERSION).tar.bz2 | tar -x -C $(DEVKITPRO)/libctru
+	bzip2 -cd libctru-$(VERSION).tar.bz2 | tar -xf - -C $(DEVKITPRO)/libctru
 
 dox:
 	@doxygen Doxyfile


### PR DESCRIPTION
Seriously though why is this piping `bzip2` into `tar` instead of just using `tar xjf`? (I know it's a relic from older dkp days, but still!)