### PR TITLE
Fix reading accelerometer and gyroscope entries.

### DIFF
--- a/libctru/source/services/hid.c
+++ b/libctru/source/services/hid.c
@@ -149,14 +149,14 @@ void hidScanInput()
 	if(Id>7)Id=7;
 	if(hidCheckSectionUpdateTime(&hidSharedMem[66], Id)==0)
 	{
-		aVec = *(accelVector*)&hidSharedMem[66 + 8 + Id*2];
+		aVec = ((accelVector*)&hidSharedMem[66 + 8])[Id];
 	}
 
 	Id = hidSharedMem[86 + 4];//Gyroscope
 	if(Id>31)Id=31;
 	if(hidCheckSectionUpdateTime(&hidSharedMem[86], Id)==0)
 	{
-		gRate = *(angularRate*)&hidSharedMem[86 + 8 + Id*2];
+		gRate = ((angularRate*)&hidSharedMem[86 + 8])[Id];
 	}
 }
 


### PR DESCRIPTION
Currently, the offsets of accelerometer and gyroscope entries are calculated as if each entry is 8 bytes large. As per the 3dbrew ["HID Shared Memory"](http://3dbrew.org/wiki/HID_Shared_Memory) page, each entry is actually 6 bytes long. Casting the base pointer to an entry pointer and using the plain ID as an index resolves this issue.