### PR TITLE
Implement some services from gsp::Lcd.

### DIFF
--- a/libctru/include/3ds/services/gsp.h
+++ b/libctru/include/3ds/services/gsp.h
@@ -50,9 +50,9 @@ typedef enum
 
 typedef enum
 {
-	GSPLCD_TOP=1,
-	GSPLCD_BOTTOM=2,
-	GSPLCD_BOTH=3,
+	GSPLCD_TOP    = BIT(0),
+	GSPLCD_BOTTOM = BIT(1),
+	GSPLCD_BOTH   = GSPLCD_TOP | GSPLCD_BOTTOM,
 }GSPLCD_Screens;
 
 Result gspInit();
@@ -90,6 +90,5 @@ Result GSPGPU_UnregisterInterruptRelayQueue(Handle* handle);
 Result GSPGPU_TriggerCmdReqQueue(Handle *handle);
 Result GSPGPU_SubmitGxCommand(u32* sharedGspCmdBuf, u32 gxCommand[0x8], Handle* handle);
 
-// 1 = top, 2 = bottom, 3 = both
-Result GSPLCD_PowerOffBacklight(u32 screen);
-Result GSPLCD_PowerOnBacklight(u32 screen);
+Result GSPLCD_PowerOffBacklight(GSPLCD_Screens screen);
+Result GSPLCD_PowerOnBacklight(GSPLCD_Screens screen);

--- a/libctru/include/3ds/services/gsp.h
+++ b/libctru/include/3ds/services/gsp.h
@@ -48,6 +48,13 @@ typedef enum
 	GSPEVENT_MAX, // used to know how many events there are
 } GSP_Event;
 
+typedef enum
+{
+	GSPLCD_TOP=1,
+	GSPLCD_BOTTOM=2,
+	GSPLCD_BOTH=3,
+}GSPLCD_Screens;
+
 Result gspInit();
 void gspExit();
 

--- a/libctru/include/3ds/services/gsp.h
+++ b/libctru/include/3ds/services/gsp.h
@@ -51,6 +51,9 @@ typedef enum
 Result gspInit();
 void gspExit();
 
+Result gspLcdInit();
+void gspLcdExit();
+
 Result gspInitEventHandler(Handle gspEvent, vu8* gspSharedMem, u8 gspThreadId);
 void gspExitEventHandler();
 void gspWaitForEvent(GSP_Event id, bool nextEvent);
@@ -79,3 +82,7 @@ Result GSPGPU_RegisterInterruptRelayQueue(Handle *handle, Handle eventHandle, u3
 Result GSPGPU_UnregisterInterruptRelayQueue(Handle* handle);
 Result GSPGPU_TriggerCmdReqQueue(Handle *handle);
 Result GSPGPU_SubmitGxCommand(u32* sharedGspCmdBuf, u32 gxCommand[0x8], Handle* handle);
+
+// 1 = top, 2 = bottom, 3 = both
+Result GSPLCD_PowerOffBacklight(u32 screen);
+Result GSPLCD_PowerOnBacklight(u32 screen);

--- a/libctru/source/services/gsp.c
+++ b/libctru/source/services/gsp.c
@@ -12,6 +12,7 @@
 #define GSP_EVENT_STACK_SIZE 0x1000
 
 Handle gspGpuHandle=0;
+Handle gspLcdHandle=0;
 Handle gspEvents[GSPEVENT_MAX];
 vu32 gspEventCounts[GSPEVENT_MAX];
 u64 gspEventStack[GSP_EVENT_STACK_SIZE/sizeof(u64)]; //u64 so that it's 8-byte aligned
@@ -430,4 +431,38 @@ Result GSPGPU_SubmitGxCommand(u32* sharedGspCmdBuf, u32 gxCommand[0x8], Handle* 
 
 	if(totalCommands==1)return GSPGPU_TriggerCmdReqQueue(handle);
 	return 0;
+}
+
+Result gspLcdInit()
+{
+	return srvGetServiceHandle(&gspLcdHandle, "gsp::Lcd");
+}
+
+void gspLcdExit()
+{
+	if(gspLcdHandle)svcCloseHandle(gspLcdHandle);
+}
+
+Result GSPLCD_PowerOffBacklight(u32 screen)
+{
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = 0x00120040;
+	cmdbuf[1] = screen;
+
+	Result ret = svcSendSyncRequest(gspLcdHandle);
+
+	return ret;
+}
+
+Result GSPLCD_PowerOnBacklight(u32 screen)
+{
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = 0x00110040;
+	cmdbuf[1] = screen;
+
+	Result ret = svcSendSyncRequest(gspLcdHandle);
+
+	return ret;
 }

--- a/libctru/source/services/gsp.c
+++ b/libctru/source/services/gsp.c
@@ -443,7 +443,7 @@ void gspLcdExit()
 	if(gspLcdHandle)svcCloseHandle(gspLcdHandle);
 }
 
-Result GSPLCD_PowerOffBacklight(u32 screen)
+Result GSPLCD_PowerOffBacklight(GSPLCD_Screens screen)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -455,7 +455,7 @@ Result GSPLCD_PowerOffBacklight(u32 screen)
 	return ret;
 }
 
-Result GSPLCD_PowerOnBacklight(u32 screen)
+Result GSPLCD_PowerOnBacklight(GSPLCD_Screens screen)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 

--- a/libctru/source/services/gsp.c
+++ b/libctru/source/services/gsp.c
@@ -450,9 +450,10 @@ Result GSPLCD_PowerOffBacklight(GSPLCD_Screens screen)
 	cmdbuf[0] = 0x00120040;
 	cmdbuf[1] = screen;
 
-	Result ret = svcSendSyncRequest(gspLcdHandle);
+	Result ret=0;
+	if ((ret = svcSendSyncRequest(gspLcdHandle)))return ret;
 
-	return ret;
+	return cmdbuf[1];
 }
 
 Result GSPLCD_PowerOnBacklight(GSPLCD_Screens screen)
@@ -462,7 +463,8 @@ Result GSPLCD_PowerOnBacklight(GSPLCD_Screens screen)
 	cmdbuf[0] = 0x00110040;
 	cmdbuf[1] = screen;
 
-	Result ret = svcSendSyncRequest(gspLcdHandle);
+	Result ret=0;
+	if ((ret = svcSendSyncRequest(gspLcdHandle)))return ret;
 
-	return ret;
+	return cmdbuf[1];
 }


### PR DESCRIPTION
http://www.3dbrew.org/wiki/GSP_Services

~~Kind of like svcBackdoor, this would require service access check patching (and therefore ARM11 kernel, I suppose?), but it'd be nice to have it for power saving.~~ It seems my makerom from project_ctr was outdated, and it's working now without requiring service access patching. I can't get my test program to work in ninjhax2 though.

One word of warning when using this service: make sure to release the handle before letting the home button be pressed/letting your application be interrupted by something; the entire 3DS console seems to hang if the currently running program has the handle. It's also a good idea to turn whichever backlight(s) on before exiting the application, since the home menu doesn't seem to re-enable it (not sure if the Homebrew Launcher does, but I assume it doesn't).

Thanks to @Megazig, @Normmatt and the others who helped me on IRC the other night.