### PR TITLE
Rewrite most documentation to be consistent in format.

### DIFF
--- a/libctru/include/3ds/console.h
+++ b/libctru/include/3ds/console.h
@@ -29,7 +29,7 @@ typedef bool(* ConsolePrint)(void* con, int c);
 //! a font struct for the console.
 typedef struct ConsoleFont
 {
-	u8* gfx;			//!< A pointer to the font graphics
+	u8* gfx;		//!< A pointer to the font graphics
 	u16 asciiOffset;	//!<  Offset to the first valid character in the font table
 	u16 numChars;		//!< Number of characters in the font graphics
 

--- a/libctru/include/3ds/gpu/shaderProgram.h
+++ b/libctru/include/3ds/gpu/shaderProgram.h
@@ -1,3 +1,7 @@
+/**
+ * @file shaderProgram.h
+ * @brief Functions for working with shaders.
+ */
 #pragma once
 
 #include <3ds/types.h>
@@ -9,7 +13,9 @@ typedef struct
 	u32 data[3];
 }float24Uniform_s;
 
-// this structure describes an instance of either a vertex or geometry shader
+/**
+ * @brief Describes an instance of either a vertex or geometry shader.
+ */
 typedef struct
 {
 	DVLE_s* dvle;
@@ -19,7 +25,9 @@ typedef struct
 	u8 numFloat24Uniforms;
 }shaderInstance_s;
 
-// this structure describes an instance of a full shader program
+/**
+ * @brief Describes an instance of a full shader program.
+ */
 typedef struct
 {
 	shaderInstance_s* vertexShader;

--- a/libctru/include/3ds/linear.h
+++ b/libctru/include/3ds/linear.h
@@ -1,8 +1,43 @@
+/**
+ * @file linear.h
+ * @brief Linear memory allocator.
+ */
 #pragma once
 
 // Functions for allocating/deallocating memory from linear heap
-void* linearAlloc(size_t size); // returns a 16-byte aligned address
+
+/**
+ * @brief Allocates a 0x80-byte aligned buffer.
+ * @param size Size of the buffer to allocate.
+ * @return The allocated buffer.
+ */
+void* linearAlloc(size_t size);
+
+/**
+ * @brief Allocates a buffer aligned to the given size.
+ * @param size Size of the buffer to allocate.
+ * @param alignment Alignment to use.
+ * @return The allocated buffer.
+ */
 void* linearMemAlign(size_t size, size_t alignment);
-void* linearRealloc(void* mem, size_t size); // not implemented yet
+
+/**
+ * @brief Reallocates a buffer.
+ * Note: Not implemented yet.
+ * @param mem Buffer to reallocate.
+ * @param size Size of the buffer to allocate.
+ * @return The reallocated buffer.
+ */
+void* linearRealloc(void* mem, size_t size);
+
+/**
+ * @brief Frees a buffer.
+ * @param mem Buffer to free.
+ */
 void linearFree(void* mem);
-u32 linearSpaceFree(void); // get free linear space in bytes
+
+/**
+ * @brief Gets the current linear free space.
+ * @return The current linear free space.
+ */
+u32 linearSpaceFree(void);

--- a/libctru/include/3ds/mappable.h
+++ b/libctru/include/3ds/mappable.h
@@ -1,6 +1,26 @@
+/**
+ * @file mappable.h
+ * @brief Mappable memory allocator.
+ */
 #pragma once
 
 // Functions for allocating/deallocating mappable memory
-void* mappableAlloc(size_t size); // returns a page-aligned address
+
+/**
+ * @brief Allocates a page-aligned buffer.
+ * @param size Size of the buffer to allocate.
+ * @return The allocated buffer.
+ */
+void* mappableAlloc(size_t size);
+
+/**
+ * @brief Frees a buffer.
+ * @param mem Buffer to free.
+ */
 void mappableFree(void* mem);
-u32 mappableSpaceFree(void); // get free mappable space in bytes
+
+/**
+ * @brief Gets the current mappable free space.
+ * @return The current mappable free space.
+ */
+u32 mappableSpaceFree(void);

--- a/libctru/include/3ds/sdmc.h
+++ b/libctru/include/3ds/sdmc.h
@@ -1,6 +1,17 @@
+/**
+ * @file sdmc.h
+ * @brief SDMC driver.
+ */
 #pragma once
 
 #include <3ds/types.h>
 
+/**
+ * @brief Initializes the SDMC driver.
+ */
 Result sdmcInit(void);
+
+/**
+ * @brief Exits the SDMC driver.
+ */
 Result sdmcExit(void);

--- a/libctru/include/3ds/services/am.h
+++ b/libctru/include/3ds/services/am.h
@@ -1,128 +1,123 @@
+/**
+ * @file am.h
+ * @brief AM (Application Manager) service.
+ */
 #pragma once
 
-/*
-	Requires access to "am:net" or "am:u" service
-*/
-
-
+/**
+ * @brief Contains basic information about a title.
+ */
 typedef struct
 {
-	u64 titleID;
-	u64 size;
-	u16 version;
-	u8 unk[6];
+	u64 titleID; ///< The title's ID.
+	u64 size;    ///< The title's installed size.
+	u16 version; ///< The title's version.
+	u8 unk[6];   ///< Unknown title data.
 } AM_TitleEntry;
 
 
+/**
+ * @brief Initializes AM.
+ */
 Result amInit(void);
+
+/**
+ * @brief Exits AM.
+ */
 Result amExit(void);
+
+/**
+ * @brief Gets the current AM session handle.
+ */
 Handle *amGetSessionHandle(void);
 
-/* AM_GetTitleCount()
-About: Gets the number of titles for a given mediatype
-
-  mediatype		mediatype to get titles from
-  count			ptr to store title count
-*/
+/**
+ * @brief Gets the number of titles for a given mediatype.
+ * @param mediatype Mediatype to get titles from.
+ * @param count Pointer to write the title count to.
+ */
 Result AM_GetTitleCount(u8 mediatype, u32 *count);
 
-/* AM_GetTitleList()
-About: Writes a titleid list for a mediatype to a buffer
-
-  mediatype		mediatype to get list from
-  count			number of titleids to get
-  titleIDs	buffer to write titleids to
-*/
+/**
+ * @brief Gets a list of title IDs present in a mediatype.
+ * @param mediatype Mediatype to get titles from.
+ * @param count Number of title IDs to get.
+ * @param titleIDs Buffer to write retreived title IDs to.
+ */
 Result AM_GetTitleIdList(u8 mediatype, u32 count, u64 *titleIDs);
 
-/* AM_GetDeviceId()
-About: Gets a 32bit device id, it's used for some key slot inits
-
-  device_id		ptr to where the device id is written to
-*/
+/**
+ * @brief Gets a 32-bit device-specific ID.
+ * @param deviceID Pointer to write the device ID to.
+ */
 Result AM_GetDeviceId(u32 *deviceID);
 
-/* AM_ListTitles()
-About: Get a list with details about the installed titles
-
-  mediatype    mediatype of title
-  titleCount   number of titles to list
-	titleIdList  pointer to a title ID list
-	titleList    pointer for the output AM_TitleEntry array
-*/
+/**
+ * @brief Gets a list of details about installed titles.
+ * @param mediatype Mediatype to get titles from.
+ * @param titleCount Number of titles to list.
+ * @param titleIdList List of title IDs to retreive details for.
+ * @param titleList Buffer to write AM_TitleEntry's to.
+ */
 Result AM_ListTitles(u8 mediatype, u32 titleCount, u64 *titleIdList, AM_TitleEntry *titleList);
 
-/**** Title Install Methods ****/
-/* AM_StartCiaInstall()
-About: Inits CIA install process, the returned ciahandle is where the data for CIA should be written to
-
-  mediatype		mediatype to install CIA to
-  ciahandle		ptr to where the handle should be written to
-*/
+/**
+ * @brief Initializes the CIA install process, returning a handle to write CIA data to.
+ * @param mediatype Mediatype to install the CIA to.
+ * @param ciaHandle Pointer to write the CIA handle to.
+ */
 Result AM_StartCiaInstall(u8 mediatype, Handle *ciaHandle);
 
-/* AM_StartDlpChildCiaInstall()
-About: Inits CIA install process, the returned ciahandle is where the data for CIA should be written to
-Note: This is for installing DLP CIAs only, mediatype is hardcoded to be NAND
-
-  ciahandle		ptr to where the handle should be written to
-*/
+/**
+ * @brief Initializes the CIA install process for Download Play CIAs, returning a handle to write CIA data to.
+ * @param ciaHandle Pointer to write the CIA handle to.
+ */
 Result AM_StartDlpChildCiaInstall(Handle *ciaHandle);
 
-/* AM_CancelCIAInstall()
-About: Abort CIA install process
-
-  ciahandle		ptr to cia Handle provided by AM
-*/
+/**
+ * @brief Aborts the CIA install process.
+ * @param ciaHandle Pointer to the CIA handle to cancel.
+ */
 Result AM_CancelCIAInstall(Handle *ciaHandle);
 
-/* AM_FinishCiaInstall()
-About: Once all data is written to the cia handle, this command signals AM to proceed with CIA install.
-Note: AM closes the cia handle provided here
-
-  mediatype		same mediatype specified ciahandle was obtained
-  ciahandle		ptr to cia Handle provided by AM
-*/
+/**
+ * @brief Finalizes the CIA install process.
+ * @param mediatype Mediatype to install the CIA to.
+ * @param ciaHandle Pointer to the CIA handle to finalize.
+ */
 Result AM_FinishCiaInstall(u8 mediatype, Handle *ciaHandle);
 
-/**** Title Delete Methods ****/
-/* AM_DeleteTitle()
-About: Deletes any title on NAND/SDMC
-Note: AM closes the cia handle provided here
-
-  mediatype		mediatype of title
-  titleid		title id of title
-*/
+/**
+ * @brief Deletes a title.
+ * @param mediatype Mediatype to delete from.
+ * @param titleID ID of the title to delete.
+ */
 Result AM_DeleteTitle(u8 mediatype, u64 titleID);
 
-/* AM_DeleteAppTitle()
-About: Deletes any title on NAND/SDMC
-Note: If the title has the system category bit set, this will fail
-
-  mediatype		mediatype of title
-  titleid		title id of title
-*/
+/**
+ * @brief Deletes a title, provided that it is not a system title.
+ * @param mediatype Mediatype to delete from.
+ * @param titleID ID of the title to delete.
+ */
 Result AM_DeleteAppTitle(u8 mediatype, u64 titleID);
 
-/* AM_InstallNativeFirm()
-About: Installs NATIVE_FIRM to NAND (firm0:/ & firm1:/) from a CXI
-*/
+/**
+ * @brief Installs the current NATIVE_FIRM title to NAND (firm0:/ & firm1:/)
+ */
 Result AM_InstallNativeFirm(void);
 
-/* AM_GetTitleProductCode()
-About: Gets the product code of a title based on its title id.
-
-  mediatype		mediatype of title
-  titleid		title id of title
-  productcode           buffer to output the product code to (should have a length of 16) 
-*/
+/**
+ * @brief Gets the product code of a title.
+ * @param mediatype Mediatype of the title.
+ * @param titleID ID of the title.
+ * @param productCode Buffer to output the product code to. (length = 16)
+ */
 Result AM_GetTitleProductCode(u8 mediatype, u64 titleID, char* productCode);
 
-/* AM_GetCiaFileInfo()
-About: Reads a CIA file and returns a AM_TitleEntry instance for it.
-
-  mediatype		destination mediatype
-  titleEntry		ptr to a AM_TitleEntry instance
-  fileHandle		a fs:USER file handle for a CIA file
-*/
+/**
+ * @brief Gets an AM_TitleEntry instance for a CIA file.
+ * @param mediatype Mediatype that this CIA would be installed to.
+ * @param titleEntry Pointer to write the AM_TitleEntry instance to.
+ * @param fileHandle Handle of the CIA file to read.
+ */
 Result AM_GetCiaFileInfo(u8 mediatype, AM_TitleEntry *titleEntry, Handle fileHandle);

--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -1,31 +1,40 @@
+/**
+ * @file apt.h
+ * @brief APT service.
+ */
 #pragma once
 
 // TODO : find a better place to put this
 #define RUNFLAG_APTWORKAROUND (BIT(0))
 #define RUNFLAG_APTREINIT (BIT(1))
 
+/**
+ * @brief NS Application IDs.
+ *
+ * Retreived from http://3dbrew.org/wiki/NS_and_APT_Services#AppIDs
+ */
 typedef enum{
-	APPID_HOMEMENU = 0x101, // Home Menu
-	APPID_CAMERA = 0x110, // Camera applet
-	APPID_FRIENDS_LIST = 0x112, // Friends List applet
-	APPID_GAME_NOTES = 0x113, // Game Notes applet
-	APPID_WEB = 0x114, // Internet Browser
-	APPID_INSTRUCTION_MANUAL = 0x115, // Instruction Manual applet
-	APPID_NOTIFICATIONS = 0x116, // Notifications applet
-	APPID_MIIVERSE = 0x117, // Miiverse applet (olv)
-	APPID_MIIVERSE_POSTING = 0x118, // Miiverse posting applet (solv3)
-	APPID_AMIIBO_SETTINGS = 0x119, // Amiibo settings applet (cabinet)
-	APPID_APPLICATION = 0x300, // Application
-	APPID_ESHOP = 0x301, // eShop (tiger)
-	APPID_SOFTWARE_KEYBOARD = 0x401, // Software Keyboard
-	APPID_APPLETED = 0x402, // appletEd
-	APPID_PNOTE_AP = 0x404, // PNOTE_AP
-	APPID_SNOTE_AP = 0x405, // SNOTE_AP
-	APPID_ERROR = 0x406, // error
-	APPID_MINT = 0x407, // mint
-	APPID_EXTRAPAD = 0x408, // extrapad
-	APPID_MEMOLIB = 0x409, // memolib
-}NS_APPID; // cf http://3dbrew.org/wiki/NS_and_APT_Services#AppIDs
+	APPID_HOMEMENU = 0x101,           ///< Home Menu
+	APPID_CAMERA = 0x110,             ///< Camera applet
+	APPID_FRIENDS_LIST = 0x112,       ///< Friends List applet
+	APPID_GAME_NOTES = 0x113,         ///< Game Notes applet
+	APPID_WEB = 0x114,                ///< Internet Browser
+	APPID_INSTRUCTION_MANUAL = 0x115, ///< Instruction Manual applet
+	APPID_NOTIFICATIONS = 0x116,      ///< Notifications applet
+	APPID_MIIVERSE = 0x117,           ///< Miiverse applet (olv)
+	APPID_MIIVERSE_POSTING = 0x118,   ///< Miiverse posting applet (solv3)
+	APPID_AMIIBO_SETTINGS = 0x119,    ///< Amiibo settings applet (cabinet)
+	APPID_APPLICATION = 0x300,        ///< Application
+	APPID_ESHOP = 0x301,              ///< eShop (tiger)
+	APPID_SOFTWARE_KEYBOARD = 0x401,  ///< Software Keyboard
+	APPID_APPLETED = 0x402,           ///< appletEd
+	APPID_PNOTE_AP = 0x404,           ///< PNOTE_AP
+	APPID_SNOTE_AP = 0x405,           ///< SNOTE_AP
+	APPID_ERROR = 0x406,              ///< error
+	APPID_MINT = 0x407,               ///< mint
+	APPID_EXTRAPAD = 0x408,           ///< extrapad
+	APPID_MEMOLIB = 0x409,            ///< memolib
+}NS_APPID;
 
 typedef enum{
 	APP_NOTINITIALIZED,
@@ -80,13 +89,26 @@ void aptOpenSession(void);
 void aptCloseSession(void);
 void aptSetStatus(APP_STATUS status);
 APP_STATUS aptGetStatus(void);
-u32 aptGetStatusPower(void);//This can be used when the status is APP_SUSPEND* to check how the return-to-menu was triggered: 0 = home-button, 1 = power-button.
+/**
+ * @brief Checks the what triggered a return-to-menu, when the status is APT_SUSPEND.
+ * @return 0 = home-button, 1 = power-button.
+ */
+u32 aptGetStatusPower(void);
 void aptSetStatusPower(u32 status);
-void aptReturnToMenu(void);//This should be called by the user application when aptGetStatus() returns APP_SUSPENDING, not calling this will result in return-to-menu being disabled with the status left at APP_SUSPENDING. This function will not return until the system returns to the application, or when the status was changed to APP_EXITING.
+/**
+ * @brief Triggers a return to the home menu.
+ *
+ * This should be called by the user application when aptGetStatus() returns APP_SUSPENDING, not calling this will result in return-to-menu being disabled with the status left at APP_SUSPENDING. This function will not return until the system returns to the application, or when the status was changed to APP_EXITING.
+ */
+void aptReturnToMenu(void);
 void aptWaitStatusEvent(void);
 void aptSignalReadyForSleep(void);
 NS_APPID aptGetMenuAppID(void);
-bool aptMainLoop(void); // Use like this in your main(): while (aptMainLoop()) { your code here... }
+/**
+ * @brief Processes the current APT status. Generally used within a main loop.
+ * @return Whether the application is closing.
+ */
+bool aptMainLoop(void);
 
 void aptHook(aptHookCookie* cookie, aptHookFn callback, void* param);
 void aptUnhook(aptHookCookie* cookie);
@@ -118,14 +140,27 @@ Result APT_PrepareToCloseApplication(u8 a);
 Result APT_CloseApplication(const u8 *param, size_t paramSize, Handle handle);
 Result APT_SetAppCpuTimeLimit(u32 percent);
 Result APT_GetAppCpuTimeLimit(u32 *percent);
-Result APT_CheckNew3DS_Application(u8 *out);// Note: this function is unreliable, see: http://3dbrew.org/wiki/APT:PrepareToStartApplication
+/**
+ * @brief Checks whether the system is a New 3DS.
+ * Note: this function is unreliable, see: http://3dbrew.org/wiki/APT:PrepareToStartApplication
+ * @param out Pointer to write the New 3DS flag to.
+ */
+Result APT_CheckNew3DS_Application(u8 *out);
 Result APT_CheckNew3DS_System(u8 *out);
 Result APT_CheckNew3DS(u8 *out);
 Result APT_PrepareToDoAppJump(u8 flags, u64 programID, u8 mediatype);
 Result APT_DoAppJump(u32 NSbuf0Size, u32 NSbuf1Size, u8 *NSbuf0Ptr, u8 *NSbuf1Ptr);
 Result APT_PrepareToStartLibraryApplet(NS_APPID appID);
 Result APT_StartLibraryApplet(NS_APPID appID, Handle inhandle, u32 *parambuf, u32 parambufsize);
-Result APT_LaunchLibraryApplet(NS_APPID appID, Handle inhandle, u32 *parambuf, u32 parambufsize);//This should be used for launching library applets, this uses the above APT_StartLibraryApplet/APT_PrepareToStartLibraryApplet funcs + apt*Session(). parambuf is used for APT params input, when the applet closes the output param block is copied here. This is not usable from the homebrew launcher. This is broken: when the applet does get launched at all, the applet process doesn't actually get terminated when the applet gets closed.
+/**
+ * @brief Launches a library applet.
+ * Note: This is not usable from the homebrew launcher. This is broken: when the applet does get launched at all, the applet process doesn't actually get terminated when the applet gets closed.
+ * @param appID ID of the applet to launch.
+ * @param inhandle Handle to pass to the applet.
+ * @param parambuf Buffer containing applet input parameters.
+ * @param parambufsize Size of parambuf.
+ */
+Result APT_LaunchLibraryApplet(NS_APPID appID, Handle inhandle, u32 *parambuf, u32 parambufsize);
 Result APT_PrepareToStartSystemApplet(NS_APPID appID);
 Result APT_StartSystemApplet(NS_APPID appID, u32 bufSize, Handle applHandle, u8 *buf);
 

--- a/libctru/include/3ds/services/csnd.h
+++ b/libctru/include/3ds/services/csnd.h
@@ -1,11 +1,18 @@
+/**
+ * @file csnd.h
+ * @brief CSND service.
+ */
 #pragma once
+
 #include <3ds/types.h>
 
 #define CSND_NUM_CHANNELS 32
 
 #define CSND_TIMER(n) (0x3FEC3FC / ((u32)(n)))
 
-// Convert a vol-pan pair into a left/right volume pair used by the hardware
+/**
+ * @brief Converts a vol-pan pair into a left/right volume pair used by the hardware.
+ */
 static inline u32 CSND_VOL(float vol, float pan)
 {
 	if (vol < 0.0) vol = 0.0;
@@ -22,10 +29,10 @@ static inline u32 CSND_VOL(float vol, float pan)
 
 enum
 {
-	CSND_ENCODING_PCM8 = 0,
-	CSND_ENCODING_PCM16,
-	CSND_ENCODING_ADPCM, // IMA-ADPCM
-	CSND_ENCODING_PSG, // Similar to DS?
+	CSND_ENCODING_PCM8 = 0, ///< PCM8
+	CSND_ENCODING_PCM16,    ///< PCM16
+	CSND_ENCODING_ADPCM,    ///< IMA-ADPCM
+	CSND_ENCODING_PSG,      ///< Similar to DS?
 };
 
 enum
@@ -61,17 +68,19 @@ enum
 	CAPTURE_ENABLE = BIT(15),
 };
 
-// Duty cycles for a PSG channel
+/**
+ * @brief Duty cycles for a PSG channel.
+ */
 enum
 {
-	DutyCycle_0  = 7, /*!<  0.0% duty cycle */
-	DutyCycle_12 = 0, /*!<  12.5% duty cycle */
-	DutyCycle_25 = 1, /*!<  25.0% duty cycle */
-	DutyCycle_37 = 2, /*!<  37.5% duty cycle */
-	DutyCycle_50 = 3, /*!<  50.0% duty cycle */
-	DutyCycle_62 = 4, /*!<  62.5% duty cycle */
-	DutyCycle_75 = 5, /*!<  75.0% duty cycle */
-	DutyCycle_87 = 6  /*!<  87.5% duty cycle */
+	DutyCycle_0  = 7, ///< 0.0% duty cycle
+	DutyCycle_12 = 0, ///< 12.5% duty cycle
+	DutyCycle_25 = 1, ///< 25.0% duty cycle
+	DutyCycle_37 = 2, ///< 37.5% duty cycle
+	DutyCycle_50 = 3, ///< 50.0% duty cycle
+	DutyCycle_62 = 4, ///< 62.5% duty cycle
+	DutyCycle_75 = 5, ///< 75.0% duty cycle
+	DutyCycle_87 = 6  ///< 87.5% duty cycle
 };
 
 typedef union
@@ -110,13 +119,26 @@ extern u32 csndChannels; // Bitmask of channels that are allowed for usage
 Result CSND_AcquireCapUnit(u32* capUnit);
 Result CSND_ReleaseCapUnit(u32 capUnit);
 
-Result CSND_Reset(void); // Currently breaks sound, don't use for now!
+/**
+ * @brief Resets CSND.
+ * Note: Currently breaks sound, don't use for now!
+ */
+Result CSND_Reset(void);
 
 Result csndInit(void);
 Result csndExit(void);
 
-u32* csndAddCmd(int cmdid); // Adds a command to the list and returns the buffer to which write its arguments.
-void csndWriteCmd(int cmdid, u8* cmdparams); // As above, but copies the arguments from an external buffer
+/**
+ * @brief Adds a command to the list and returns the buffer to write its arguments to.
+ * @param cmdid ID of the command to add.
+ */
+u32* csndAddCmd(int cmdid);
+/**
+ * @brief Adds a command to the list and copies its arguments from a buffer.
+ * @param cmdid ID of the command to add.
+ * @param cmdparams Buffer containing the command's parameters.
+ */
+void csndWriteCmd(int cmdid, u8* cmdparams);
 Result csndExecCmds(bool waitDone);
 
 void CSND_SetPlayStateR(u32 channel, u32 value);
@@ -147,14 +169,30 @@ Result CSND_SetDspFlags(bool waitDone);
 Result CSND_UpdateInfo(bool waitDone);
 
 /**
- * @param vol The volume, ranges from 0.0 to 1.0 included
- * @param pan The pan, ranges from -1.0 to 1.0 included
+ * @brief Plays a sound.
+ * @param chn Channel to play the sound on.
+ * @param flags Flags containing information about the sound.
+ * @param sampleRate Sample rate of the sound.
+ * @param vol The volume, ranges from 0.0 to 1.0 included.
+ * @param pan The pan, ranges from -1.0 to 1.0 included.
+ * @param data0 First block of sound data.
+ * @param data1 Second block of sound data. Used as a loop destination.
+ * @param size Size of the sound data.
  */
 Result csndPlaySound(int chn, u32 flags, u32 sampleRate, float vol, float pan, void* data0, void* data1, u32 size);
 
-void csndGetDspFlags(u32* outSemFlags, u32* outIrqFlags); // Requires previous CSND_UpdateInfo()
-CSND_ChnInfo* csndGetChnInfo(u32 channel); // Requires previous CSND_UpdateInfo()
-CSND_CapInfo* csndGetCapInfo(u32 capUnit); // Requires previous CSND_UpdateInfo()
+/**
+ * Note: Requires previous CSND_UpdateInfo()
+ */
+void csndGetDspFlags(u32* outSemFlags, u32* outIrqFlags);
+/**
+ * Note: Requires previous CSND_UpdateInfo()
+ */
+CSND_ChnInfo* csndGetChnInfo(u32 channel);
+/**
+ * Note: Requires previous CSND_UpdateInfo()
+ */
+CSND_CapInfo* csndGetCapInfo(u32 capUnit);
 
 Result csndGetState(u32 channel, CSND_ChnInfo* out);
 Result csndIsPlaying(u32 channel, u8* status);

--- a/libctru/include/3ds/services/gsp.h
+++ b/libctru/include/3ds/services/gsp.h
@@ -1,28 +1,35 @@
+/**
+ * @file gsp.h
+ * @brief GSP service.
+ */
 #pragma once
 
 #define GSP_REBASE_REG(r) ((r)-0x1EB00000)
 
 typedef struct
 {
-	u32 active_framebuf;//"0=first, 1=second"
-	u32 *framebuf0_vaddr;//"Framebuffer virtual address, for the main screen this is the 3D left framebuffer"
-	u32 *framebuf1_vaddr;//"For the main screen: 3D right framebuffer address"
-	u32 framebuf_widthbytesize;//"Value for 0x1EF00X90, controls framebuffer width"
-	u32 format;//"Framebuffer format, this u16 is written to the low u16 for LCD register 0x1EF00X70."
-	u32 framebuf_dispselect;//"Value for 0x1EF00X78, controls which framebuffer is displayed"
-	u32 unk;//"?"
+	u32 active_framebuf;        ///< "0=first, 1=second"
+	u32 *framebuf0_vaddr;       ///< "Framebuffer virtual address, for the main screen this is the 3D left framebuffer"
+	u32 *framebuf1_vaddr;       ///< "For the main screen: 3D right framebuffer address"
+	u32 framebuf_widthbytesize; ///< "Value for 0x1EF00X90, controls framebuffer width"
+	u32 format;                 ///< "Framebuffer format, this u16 is written to the low u16 for LCD register 0x1EF00X70."
+	u32 framebuf_dispselect;    ///< "Value for 0x1EF00X78, controls which framebuffer is displayed"
+	u32 unk;                    ///< "?"
 } GSP_FramebufferInfo;
 
 typedef enum
 {
-	GSP_RGBA8_OES=0, //pixel_size = 4-bytes
-	GSP_BGR8_OES=1, //pixel_size = 3-bytes
-	GSP_RGB565_OES=2, //pixel_size = 2-bytes
-	GSP_RGB5_A1_OES=3, //pixel_size = 2-bytes
-	GSP_RGBA4_OES=4 //pixel_size = 2-bytes
+	GSP_RGBA8_OES=0,   ///< pixel_size = 4-bytes
+	GSP_BGR8_OES=1,    ///< pixel_size = 3-bytes
+	GSP_RGB565_OES=2,  ///< pixel_size = 2-bytes
+	GSP_RGB5_A1_OES=3, ///< pixel_size = 2-bytes
+	GSP_RGBA4_OES=4    ///< pixel_size = 2-bytes
 }GSP_FramebufferFormats;
 
-typedef struct//See this for GSP_CaptureInfoEntry and GSP_CaptureInfo: http://3dbrew.org/wiki/GSPGPU:ImportDisplayCaptureInfo
+/**
+ * See this for GSP_CaptureInfoEntry and GSP_CaptureInfo: http://3dbrew.org/wiki/GSPGPU:ImportDisplayCaptureInfo
+ */
+typedef struct
 {
 	u32 *framebuf0_vaddr;
 	u32 *framebuf1_vaddr;
@@ -37,15 +44,15 @@ typedef struct
 
 typedef enum
 {
-	GSPEVENT_PSC0 = 0,	// memory fill completed
+	GSPEVENT_PSC0 = 0, ///< memory fill completed
 	GSPEVENT_PSC1,
 	GSPEVENT_VBlank0,
 	GSPEVENT_VBlank1,
-	GSPEVENT_PPF,		// display transfer finished
-	GSPEVENT_P3D,		// command list processing finished
+	GSPEVENT_PPF,      ///< display transfer finished
+	GSPEVENT_P3D,      ///< command list processing finished
 	GSPEVENT_DMA,
 
-	GSPEVENT_MAX, // used to know how many events there are
+	GSPEVENT_MAX,      ///< used to know how many events there are
 } GSP_Event;
 
 typedef enum

--- a/libctru/include/3ds/services/hb.h
+++ b/libctru/include/3ds/services/hb.h
@@ -1,5 +1,8 @@
-#ifndef HB_H
-#define HB_H
+/**
+ * @file hb.h
+ * @brief HB (Homebrew) service.
+ */
+#pragma once
 
 // WARNING ! THIS FILE PROVIDES AN INTERFACE TO A NON-OFFICIAL SERVICE PROVIDED BY NINJHAX
 // BY USING COMMANDS FROM THIS SERVICE YOU WILL LIKELY MAKE YOUR APPLICATION INCOMPATIBLE WITH OTHER HOMEBREW LAUNCHING METHODS
@@ -7,21 +10,35 @@
 
 #include <3ds/types.h>
 
+/**
+ * @brief Initializes HB.
+ */
 Result hbInit();
+
+/**
+ * @brief Exits HB.
+ */
 void hbExit();
 
-// flushes/invalidates entire data/instruction cache
-// can be useful when writing code to executable pages
+/**
+ * @brief Flushes/invalidates the entire data/instruction cache.
+ */
 Result HB_FlushInvalidateCache(void);
 
-// fetches the address for ninjhax bootloader addresses, useful for running 3dsx executables
-// void (*callBootloader)(Handle hb, Handle file);
-// void (*setArgs)(u32* src, u32 length);
+/**
+ * @brief Fetches the address for Ninjhax 1.x bootloader addresses.
+ * @param load3dsx void (*callBootloader)(Handle hb, Handle file);
+ * @param setArgv void (*setArgs)(u32* src, u32 length);
+ */
 Result HB_GetBootloaderAddresses(void** load3dsx, void** setArgv);
 
-// changes the permissions of a given number of pages at address addr to mode
-// should it fail, the appropriate kernel error code will be returned and *reprotectedPages (if not NULL)
-// will be set to the number of sequential pages which were successfully reprotected + 1
+/**
+ * @brief Changes the permissions of a given number of pages at address addr to mode.
+ * Should it fail, the appropriate kernel error code will be returned and *reprotectedPages (if not NULL)
+ * will be set to the number of sequential pages which were successfully reprotected + 1
+ * @param addr Address to reprotect.
+ * @param pages Number of pages to reprotect.
+ * @param mode Mode to reprotect to.
+ * @param reprotectedPages Number of successfully reprotected pages, on failure.
+ */
 Result HB_ReprotectMemory(u32* addr, u32 pages, u32 mode, u32* reprotectedPages);
-
-#endif

--- a/libctru/include/3ds/services/hid.h
+++ b/libctru/include/3ds/services/hid.h
@@ -1,3 +1,7 @@
+/**
+ * @file hid.h
+ * @brief HID service.
+ */
 #pragma once
 
 //See also: http://3dbrew.org/wiki/HID_Services http://3dbrew.org/wiki/HID_Shared_Memory
@@ -16,17 +20,17 @@ typedef enum
 	KEY_L       = BIT(9),
 	KEY_X       = BIT(10),
 	KEY_Y       = BIT(11),
-	KEY_ZL      = BIT(14), // (new 3DS only)
-	KEY_ZR      = BIT(15), // (new 3DS only)
-	KEY_TOUCH   = BIT(20), // Not actually provided by HID
-	KEY_CSTICK_RIGHT = BIT(24), // c-stick (new 3DS only)
-	KEY_CSTICK_LEFT  = BIT(25), // c-stick (new 3DS only)
-	KEY_CSTICK_UP    = BIT(26), // c-stick (new 3DS only)
-	KEY_CSTICK_DOWN  = BIT(27), // c-stick (new 3DS only)
-	KEY_CPAD_RIGHT = BIT(28), // circle pad
-	KEY_CPAD_LEFT  = BIT(29), // circle pad
-	KEY_CPAD_UP    = BIT(30), // circle pad
-	KEY_CPAD_DOWN  = BIT(31), // circle pad
+	KEY_ZL      = BIT(14),      ///< ZL (new 3DS only)
+	KEY_ZR      = BIT(15),      ///< ZR (new 3DS only)
+	KEY_TOUCH   = BIT(20),      ///< Not actually provided by HID
+	KEY_CSTICK_RIGHT = BIT(24), ///< c-stick right (new 3DS only)
+	KEY_CSTICK_LEFT  = BIT(25), ///< c-stick left (new 3DS only)
+	KEY_CSTICK_UP    = BIT(26), ///< c-stick up (new 3DS only)
+	KEY_CSTICK_DOWN  = BIT(27), ///< c-stick down (new 3DS only)
+	KEY_CPAD_RIGHT = BIT(28),   ///< circle pad right
+	KEY_CPAD_LEFT  = BIT(29),   ///< circle pad left
+	KEY_CPAD_UP    = BIT(30),   ///< circle pad up
+	KEY_CPAD_DOWN  = BIT(31),   ///< circle pad down
 
 	// Generic catch-all directions
 	KEY_UP    = KEY_DUP    | KEY_CPAD_UP,
@@ -54,20 +58,20 @@ typedef struct
 
 typedef struct
 {
-	s16 x;//roll
-	s16 z;//yaw
-	s16 y;//pitch
+	s16 x; ///< roll
+	s16 z; ///< yaw
+	s16 y; ///< pitch
 } angularRate;
 
 typedef enum
 {
-	HIDEVENT_PAD0 = 0, //"Event signaled by HID-module, when the sharedmem+0(PAD/circle-pad)/+0xA8(touch-screen) region was updated."
-	HIDEVENT_PAD1, //"Event signaled by HID-module, when the sharedmem+0(PAD/circle-pad)/+0xA8(touch-screen) region was updated."
-	HIDEVENT_Accel, //"Event signaled by HID-module, when the sharedmem accelerometer state was updated."
-	HIDEVENT_Gyro, //"Event signaled by HID-module, when the sharedmem gyroscope state was updated."
-	HIDEVENT_DebugPad, //"Event signaled by HID-module, when the sharedmem DebugPad state was updated."
+	HIDEVENT_PAD0 = 0, ///< "Event signaled by HID-module, when the sharedmem+0(PAD/circle-pad)/+0xA8(touch-screen) region was updated."
+	HIDEVENT_PAD1,     ///< "Event signaled by HID-module, when the sharedmem+0(PAD/circle-pad)/+0xA8(touch-screen) region was updated."
+	HIDEVENT_Accel,    ///< "Event signaled by HID-module, when the sharedmem accelerometer state was updated."
+	HIDEVENT_Gyro,     ///< "Event signaled by HID-module, when the sharedmem gyroscope state was updated."
+	HIDEVENT_DebugPad, ///< "Event signaled by HID-module, when the sharedmem DebugPad state was updated."
 
-	HIDEVENT_MAX, // used to know how many events there are
+	HIDEVENT_MAX,      ///< used to know how many events there are
 } HID_Event;
 
 extern Handle hidMemHandle;
@@ -101,4 +105,8 @@ Result HIDUSER_DisableAccelerometer(void);
 Result HIDUSER_EnableGyroscope(void);
 Result HIDUSER_DisableGyroscope(void);
 Result HIDUSER_GetGyroscopeRawToDpsCoefficient(float *coeff);
-Result HIDUSER_GetSoundVolume(u8 *volume); //Return the volume slider value (0-63)
+/**
+ * @brief Gets the current volume slider value. (0-63)
+ * @param volume Pointer to write the volume slider value to.
+ */
+Result HIDUSER_GetSoundVolume(u8 *volume);

--- a/libctru/include/3ds/services/httpc.h
+++ b/libctru/include/3ds/services/httpc.h
@@ -1,3 +1,7 @@
+/**
+ * @file httpc.h
+ * @brief HTTP service.
+ */
 #pragma once
 
 typedef struct {
@@ -15,16 +19,36 @@ typedef enum{
 Result httpcInit(void);
 void httpcExit(void);
 
-Result httpcOpenContext(httpcContext *context, char* url, u32 use_defaultproxy);//use_defaultproxy should be zero normally, unless you don't want HTTPC_SetProxyDefault() to be used automatically.
+/**
+ * @brief Opens an HTTP context.
+ * @param context Context to open.
+ * @param url URL to connect to.
+ * @param use_defaultproxy Whether the default proxy should be used (0 for default)
+ */
+Result httpcOpenContext(httpcContext *context, char* url, u32 use_defaultproxy);
 Result httpcCloseContext(httpcContext *context);
 Result httpcAddRequestHeaderField(httpcContext *context, char* name, char* value);
 Result httpcBeginRequest(httpcContext *context);
 Result httpcReceiveData(httpcContext *context, u8* buffer, u32 size);
 Result httpcGetRequestState(httpcContext *context, httpcReqStatus* out);
 Result httpcGetDownloadSizeState(httpcContext *context, u32* downloadedsize, u32* contentsize);
-Result httpcGetResponseStatusCode(httpcContext *context, u32* out, u64 delay);//delay isn't used yet. This writes the HTTP status code from the server to out.
+/**
+ * @brief Gets the response code of the HTTP context.
+ * @param context Context to get the response code of.
+ * @param out Pointer to write the response code to.
+ * @param delay Delay to wait for the status code. Not used yet.
+ */
+Result httpcGetResponseStatusCode(httpcContext *context, u32* out, u64 delay);
 Result httpcGetResponseHeader(httpcContext *context, char* name, char* value, u32 valuebuf_maxsize);
-Result httpcDownloadData(httpcContext *context, u8* buffer, u32 size, u32 *downloadedsize);//The *entire* content must be downloaded before using httpcCloseContext(), otherwise httpcCloseContext() will hang.
+/**
+ * @brief Downloads data from the HTTP context into a buffer.
+ * The *entire* content must be downloaded before using httpcCloseContext(), otherwise httpcCloseContext() will hang.
+ * @param context Context to download data from.
+ * @param buffer Buffer to write data to.
+ * @param size Size of the buffer.
+ * @param downloadedsize Pointer to write the size of the downloaded data to.
+ */
+Result httpcDownloadData(httpcContext *context, u8* buffer, u32 size, u32 *downloadedsize);
 
 //Using the below functions directly is not recommended, use the above functions. See also the http example.
 

--- a/libctru/include/3ds/services/ir.h
+++ b/libctru/include/3ds/services/ir.h
@@ -1,6 +1,16 @@
+/**
+ * @file ir.h
+ * @brief IR service.
+ */
 #pragma once
 
-Result IRU_Initialize(u32 *sharedmem_addr, u32 sharedmem_size);//The permissions for the specified memory is set to RO. This memory must be already mapped.
+/**
+ * @brief Initializes IRU.
+ * The permissions for the specified memory is set to RO. This memory must be already mapped.
+ * @param sharedmem_addr Address of the shared memory block to use.
+ * @param sharedmem_size Size of the shared memory block.
+ */
+Result IRU_Initialize(u32 *sharedmem_addr, u32 sharedmem_size);
 Result IRU_Shutdown(void);
 Handle IRU_GetServHandle(void);
 Result IRU_SendData(u8 *buf, u32 size, u32 wait);

--- a/libctru/include/3ds/services/mic.h
+++ b/libctru/include/3ds/services/mic.h
@@ -1,11 +1,37 @@
+/**
+ * @file mic.h
+ * @brief MIC (Microphone) service.
+ */
 #pragma once
 
 //See also: http://3dbrew.org/wiki/MIC_Services
 
-Result MIC_Initialize(u32 *sharedmem, u32 sharedmem_size, u8 control, u8 recording, u8 unk0, u8 unk1, u8 unk2);//sharedmem_size = audiodata size + 4, aligned to 0x1000-bytes. The sharedmem ptr must be 0x1000-bytes aligned. The offical 3ds-sound app uses the following values for unk0-unk2: 3, 1, and 1.
+/**
+ * @brief Initializes MIC.
+ * @param sharedmem Shared memory block to use. Must be 0x1000-bytes aligned.
+ * @param sharedmem_size Size of the shared memory block to use. (audiodata size + 4, aligned to 0x1000-bytes)
+ * @param control Control. TODO: Document parameter.
+ * @param unk0 Unknown. Typically 3.
+ * @param unk1 Unknown. Typically 1.
+ * @param unk2 Unknown. Typically 1.
+ */
+Result MIC_Initialize(u32 *sharedmem, u32 sharedmem_size, u8 control, u8 recording, u8 unk0, u8 unk1, u8 unk2);
+
+/**
+ * @brief Shuts down MIC.
+ */
 Result MIC_Shutdown(void);
+
 u32 MIC_GetSharedMemOffsetValue(void);
-u32 MIC_ReadAudioData(u8 *outbuf, u32 readsize, u32 waitforevent);//Reads MIC audio data. When waitforevent is non-zero, this clears the event, then waits for MIC-module to signal it again when audio data is written to shared-mem. The return value is the actual byte-size of the read data.
+
+/**
+ * @brief Reads MIC audio data.
+ * @param outbuf Buffer to write audio data to.
+ * @param readsize Size of the buffer to write to.
+ * @param waitforevent Whether to wait for the MIC service to signal that audio data is ready. (non-zero = wait)
+ * @return Actual number of bytes read.
+ */
+u32 MIC_ReadAudioData(u8 *outbuf, u32 readsize, u32 waitforevent);
 
 Result MIC_MapSharedMem(Handle handle, u32 size);
 Result MIC_UnmapSharedMem(void);
@@ -13,7 +39,10 @@ Result MIC_cmd3_Initialize(u8 unk0, u8 unk1, u32 sharedmem_baseoffset, u32 share
 Result MIC_cmd5(void);
 Result MIC_GetCNTBit15(u8 *out);
 Result MIC_GetEventHandle(Handle *handle);
-Result MIC_SetControl(u8 value);//See here: http://3dbrew.org/wiki/MIC_Services
+/**
+ * See here: http://3dbrew.org/wiki/MIC_Services
+ */
+Result MIC_SetControl(u8 value);
 Result MIC_GetControl(u8 *value);
 Result MIC_SetRecording(u8 value);
 Result MIC_IsRecoding(u8 *value);

--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -1,3 +1,7 @@
+/**
+ * @file mvd.h
+ * @brief MVD service.
+ */
 #pragma once
 
 //New3DS-only, see also: http://3dbrew.org/wiki/MVD_Services
@@ -37,7 +41,15 @@ typedef struct {
 
 void mvdstdGenerateDefaultConfig(mvdstdConfig *config, u32 input_width, u32 input_height, u32 output_width, u32 output_height, u32 *vaddr_colorconv_indata, u32 *vaddr_outdata0, u32 *vaddr_outdata1_colorconv);
 
-Result mvdstdInit(mvdstdMode mode, mvdstdTypeInput input_type, mvdstdTypeOutput output_type, u32 size);//The input size isn't used when type==MVDTYPE_COLORFORMATCONV. Video processing / H.264 isn't supported currently.
+/**
+ * @brief Initializes MVDSTD.
+ * Video processing / H.264 isn't supported currently.
+ * @param mode Mode to initialize MVDSTD to.
+ * @param input_type Type of input to process.
+ * @param output_type Type of output to produce.
+ * @param size Size of data to process. Not used when type == MVDTYPE_COLORFORMATCONV.
+ */
+Result mvdstdInit(mvdstdMode mode, mvdstdTypeInput input_type, mvdstdTypeOutput output_type, u32 size);
 Result mvdstdShutdown(void);
 
 Result mvdstdSetConfig(mvdstdConfig *config);

--- a/libctru/include/3ds/services/news.h
+++ b/libctru/include/3ds/services/news.h
@@ -1,22 +1,27 @@
+/**
+ * @file news.h
+ * @brief NEWS (Notification) service.
+ */
 #pragma once
 
-/*
-	Requires access to "news:u" service.
-*/
-
-
+/**
+ * @brief Initializes NEWS.
+ */
 Result newsInit(void);
+
+/**
+ * @brief Exits NEWS.
+ */
 Result newsExit(void);
 
-/* NEWSU_AddNotification()
-About: Adds a notification to the home menu Notifications applet.
-
-  title	UTF-16 title of the notification.
-  titleLength	Number of characters in the title, not including the null-terminator.
-  title	UTF-16 message of the notification, or NULL for no message.
-  titleLength	Number of characters in the message, not including the null-terminator.
-  image	Data of the image to show in the notification, or NULL for no image.
-  imageSize	Size of the image data in bytes.
-  jpeg		Whether the image is a JPEG or not.
-*/
+/**
+ * @brief Adds a notification to the home menu Notifications applet.
+ * @param title UTF-16 title of the notification.
+ * @param titleLength Number of characters in the title, not including the null-terminator.
+ * @param message UTF-16 message of the notification, or NULL for no message.
+ * @param messageLength Number of characters in the message, not including the null-terminator.
+ * @param image Data of the image to show in the notification, or NULL for no image.
+ * @param imageSize Size of the image data in bytes.
+ * @param jpeg Whether the image is a JPEG or not.
+ */
 Result NEWSU_AddNotification(const u16* title, u32 titleLength, const u16* message, u32 messageLength, const void* imageData, u32 imageSize, bool jpeg);

--- a/libctru/include/3ds/services/ns.h
+++ b/libctru/include/3ds/services/ns.h
@@ -1,21 +1,30 @@
+/**
+ * @file ns.h
+ * @brief NS (Nintendo Shell) service.
+ */
 #pragma once
 
-/*
-	Requires access to "ns:s" service
-*/
-
+/**
+ * @brief Initializes NS.
+ */
 Result nsInit(void);
+
+/**
+ * @brief Exits NS.
+ */
 Result nsExit(void);
 
-/* NS_LaunchTitle()
-  titleid			TitleId of title to launch, if 0, gamecard assumed
-  launch_flags		use if you know of any
-  procid			ptr to where the process id of the launched title will be written to, leave a NULL, if you don't care
-*/
+/**
+ * @brief Launches a title.
+ * @param titleid ID of the title to launch, or 0 for gamecard.
+ * @param launch_flags Flags used when launching the title.
+ * @param procid Pointer to write the process ID of the launched title to.
+ */
 Result NS_LaunchTitle(u64 titleid, u32 launch_flags, u32 *procid);
 
-/* NS_RebootToTitle()
-  mediatype			mediatype for title
-  titleid			TitleId of title to launch
-*/
+/**
+ * @brief Reboots to a title.
+ * @param mediatype Mediatype of the title.
+ * @param titleid ID of the title to launch.
+ */
 Result NS_RebootToTitle(u8 mediatype, u64 titleid);

--- a/libctru/include/3ds/services/pm.h
+++ b/libctru/include/3ds/services/pm.h
@@ -1,51 +1,53 @@
+/**
+ * @file pm.h
+ * @brief PM (Process Manager) service.
+ */
 #pragma once
 
-/*
-	Requires access to "pm:app" service
-*/
-
+/**
+ * @brief Initializes PM.
+ */
 Result pmInit(void);
+
+/**
+ * @brief Exits PM.
+ */
 Result pmExit(void);
 
-/* PM_LaunchTitle()
-About: Launches a title
-
-  mediatype		mediatype of title
-  titleid		TitleId of title to launch
-  launch_flags	use if you know of any
-*/
+/**
+ * @brief Launches a title.
+ * @param mediatype Mediatype of the title.
+ * @param titleid ID of the title.
+ * @param launch_flags Flags to launch the title with.
+ */
 Result PM_LaunchTitle(u8 mediatype, u64 titleid, u32 launch_flags);
 
-/* PM_GetTitleExheaderFlags()
-About: Writes to a buffer the launch flags (8 bytes) from a title exheader.
-
-  mediatype		mediatype of title
-  titleid		TitleId of title
-  out			ptr to where the flags should be written to
-*/
+/**
+ * @brief Gets launch flags from a title's exheader.
+ * @param mediatype Mediatype of the title.
+ * @param titleid ID of the title.
+ * @param out Pointer to write the launch flags to.
+ */
 Result PM_GetTitleExheaderFlags(u8 mediatype, u64 titleid, u8* out);
 
-/* PM_SetFIRMLaunchParams()
-About: Sets the FIRM launch params from in
-
-  size			size of FIRM launch params
-  in			ptr to location of FIRM launch params
-*/
+/**
+ * @brief Sets the current FIRM launch parameters.
+ * @param size Size of the FIRM launch parameter buffer.
+ * @param in Buffer to retreive the launch parameters from.
+ */
 Result PM_SetFIRMLaunchParams(u32 size, u8* in);
 
-/* PM_GetFIRMLaunchParams()
-About: Sets the FIRM launch params from in
-
-  size			size of buffer to store FIRM launch params
-  out			ptr to location to write FIRM launch params
-*/
+/**
+ * @brief Gets the current FIRM launch parameters.
+ * @param size Size of the FIRM launch parameter buffer.
+ * @param out Buffer to write the launch parameters to.
+ */
 Result PM_GetFIRMLaunchParams(u32 size, u8* out);
 
-/* PM_SetFIRMLaunchParams()
-About: Same as PM_SetFIRMLaunchParams(), but also triggers a FIRM launch
-
-  firm_titleid_low	TitleID low of firm title to launch
-  size				size of FIRM launch params
-  in				ptr to location of FIRM launch params
-*/
+/**
+ * @brief Sets the current FIRM launch parameters.
+ * @param firm_titleid_low Low Title ID of the FIRM title to launch.
+ * @param size Size of the FIRM launch parameter buffer.
+ * @param in Buffer to retreive the launch parameters from.
+ */
 Result PM_LaunchFIRMSetParams(u32 firm_titleid_low, u32 size, u8* in);

--- a/libctru/include/3ds/services/ps.h
+++ b/libctru/include/3ds/services/ps.h
@@ -1,77 +1,84 @@
+/**
+ * @file ps.h
+ * @brief PS service.
+ */
 #pragma once
 
+/**
+ * @brief PS AES algorithms.
+ */
 typedef enum
 {
-	ps_CBC_ENC,
-	ps_CBC_DEC,
-	ps_CTR_ENC,
-	ps_CTR_DEC,
-	ps_CCM_ENC,
-	ps_CCM_DEC,
+	ps_CBC_ENC, ///< CBC encoding.
+	ps_CBC_DEC, ///< CBC decoding.
+	ps_CTR_ENC, ///< CTR encoding.
+	ps_CTR_DEC, ///< CTR decoding.
+	ps_CCM_ENC, ///< CCM encoding.
+	ps_CCM_DEC, ///< CCM decoding.
 } ps_aes_algo;
 
+/**
+ * @brief PS key slots.
+ */
 typedef enum
 {
-	ps_KEYSLOT_0D,
-	ps_KEYSLOT_2D,
-	ps_KEYSLOT_31,
-	ps_KEYSLOT_38,
-	ps_KEYSLOT_32,
-	ps_KEYSLOT_39_DLP,
-	ps_KEYSLOT_2E,
-	ps_KEYSLOT_INVALID,
-	ps_KEYSLOT_36,
-	ps_KEYSLOT_39_NFC
+	ps_KEYSLOT_0D,      ///< Key slot 0x0D.
+	ps_KEYSLOT_2D,      ///< Key slot 0x2D.
+	ps_KEYSLOT_31,      ///< Key slot 0x31.
+	ps_KEYSLOT_38,      ///< Key slot 0x38.
+	ps_KEYSLOT_32,      ///< Key slot 0x32.
+	ps_KEYSLOT_39_DLP,  ///< Key slot 0x39. (DLP)
+	ps_KEYSLOT_2E,      ///< Key slot 0x2E.
+	ps_KEYSLOT_INVALID, ///< Invalid key slot.
+	ps_KEYSLOT_36,      ///< Key slot 0x36.
+	ps_KEYSLOT_39_NFC   ///< Key slot 0x39. (NFC)
 } ps_aes_keytypes;
 
-/*
-	Requires access to "ps:ps" service
-*/
-
+/**
+ * @brief Initializes PS.
+ */
 Result psInit(void);
+
+/**
+ * @brief Exits PS.
+ */
 Result psExit(void);
 
-/* PS_EncryptDecryptAes()
-About: Is an interface for the AES Engine, you can only use predetermined keyslots though.
-Note: Does not support AES CCM, see PS_EncryptSignDecryptVerifyAesCcm()
-
-  size			size of data
-  in			input buffer ptr
-  out			output buffer ptr
-  aes_algo		AES Algorithm to use, see ps_aes_algo
-  key_type		see ps_aes_keytypes
-  iv			ptr to the CTR/IV (This is updated before returning)
-*/
+/**
+ * @brief Encrypts/Decrypts AES data. Does not support AES CCM.
+ * @param size Size of the data.
+ * @param in Input buffer.
+ * @param out Output buffer.
+ * @param aes_algo AES algorithm to use.
+ * @param key_type Key type to use.
+ * @param iv Pointer to the CTR/IV.
+ */
 Result PS_EncryptDecryptAes(u32 size, u8* in, u8* out, u32 aes_algo, u32 key_type, u8* iv);
 
-/* PS_EncryptSignDecryptVerifyAesCcm()
-About: Is an interface for the AES Engine (CCM Encrypt/Decrypt only), you can only use predetermined keyslots though.
-Note: When encrypting, the output buffer size must include the MAC size, when decrypting, the input buffer size must include MAC size.
-MAC: When decrypting, if the MAC is invalid, 0xC9010401 is returned. After encrypting the MAC is located at inputbufptr+(totalassocdata+totaldatasize)
-
-  in			input buffer ptr
-  in_size		size of input buffer
-  out			output buffer ptr
-  out_size		size of output buffer
-  data_len		length of data to be crypted
-  mac_data_len	length of data associated with MAC
-  mac_len		length of MAC
-  aes_algo		AES Algorithm to use, see ps_aes_algo
-  key_type		see ps_aes_keytypes
-  nonce			ptr to the nonce
-*/
+/**
+ * @brief Encrypts/Decrypts signed AES CCM data.
+ * When decrypting, if the MAC is invalid, 0xC9010401 is returned. After encrypting the MAC is located at inputbufptr.
+ * @param in Input buffer.
+ * @param in_size Size of the input buffer. Must include MAC size when decrypting.
+ * @param out Output buffer.
+ * @param out_size Size of the output buffer. Must include MAC size when encrypting.
+ * @param data_len Length of the data to be encrypted/decrypted.
+ * @param mac_data_len Length of the MAC data.
+ * @param mac_len Length of the MAC.
+ * @param aes_algo AES algorithm to use.
+ * @param key_type Key type to use.
+ * @param nonce Pointer to the nonce.
+ */
 Result PS_EncryptSignDecryptVerifyAesCcm(u8* in, u32 in_size, u8* out, u32 out_size, u32 data_len, u32 mac_data_len, u32 mac_len, u32 aes_algo, u32 key_type, u8* nonce);
 
-/* PS_GetLocalFriendCodeSeed()
-About: Gets a 64bit console id, it's used for some key slot inits
-
-  seed			ptr to where the seed is written to
-*/
+/**
+ * @brief Gets the 64-bit console friend code seed.
+ * @param seed Pointer to write the friend code seed to.
+ */
 Result PS_GetLocalFriendCodeSeed(u64* seed);
 
-/* PS_GetDeviceId()
-About: Gets a 32bit device id, it's used for some key slot inits
-
-  device_id		ptr to where the device id is written to
-*/
+/**
+ * @brief Gets the 32-bit device ID.
+ * @param device_id Pointer to write the device ID to.
+ */
 Result PS_GetDeviceId(u32* device_id);

--- a/libctru/include/3ds/services/qtm.h
+++ b/libctru/include/3ds/services/qtm.h
@@ -1,25 +1,66 @@
+/**
+ * @file qtm.h
+ * @brief QTM service.
+ */
 #pragma once
 
 //See also: http://3dbrew.org/wiki/QTM_Services
 
+/**
+ * @brief Head tracking coordinate pair.
+ */
 typedef struct {
-	float x;
-	float y;
+	float x; ///< X coordinate.
+	float y; ///< Y coordinate.
 } qtmHeadtrackingInfoCoord;
 
+/**
+ * @brief Head tracking info.
+ */
 typedef struct {
-	u8 flags[5];
-	u8 padding[3];
-	float floatdata_x08;//"not used by System_Settings."
-	qtmHeadtrackingInfoCoord coords0[4];
-	u32 unk_x2c[5];//"Not used by System_Settings."
+	u8 flags[5];                         ///< Flags.
+	u8 padding[3];                       ///< Padding.
+	float floatdata_x08;                 ///< Unknown. Not used by System_Settings.
+	qtmHeadtrackingInfoCoord coords0[4]; ///< Head coordinates.
+	u32 unk_x2c[5];                      ///< Unknown. Not used by System_Settings.
 } qtmHeadtrackingInfo;
 
+/**
+ * @brief Initializes QTM.
+ */
 Result qtmInit(void);
+
+/**
+ * @brief Exits QTM.
+ */
 void qtmExit(void);
+
+/**
+ * @brief Checks whether QTM is initialized.
+ * @return Whether QTM is initialized.
+ */
 bool qtmCheckInitialized(void);
 
-Result qtmGetHeadtrackingInfo(u64 val, qtmHeadtrackingInfo *out);//val is normally 0.
+/**
+ * @brief Gets the current head tracking info.
+ * @param val Normally 0.
+ * @param out Pointer to write head tracking info to.
+ */
+Result qtmGetHeadtrackingInfo(u64 val, qtmHeadtrackingInfo *out);
+
+/**
+ * @brief Checks whether a head is fully detected.
+ * @param info Tracking info to check.
+ */
 bool qtmCheckHeadFullyDetected(qtmHeadtrackingInfo *info);
-Result qtmConvertCoordToScreen(qtmHeadtrackingInfoCoord *coord, float *screen_width, float *screen_height, u32 *x, u32 *y);//screen_* can be NULL to use the default values for the top-screen.
+
+/**
+ * @brief Converts QTM coordinates to screen coordinates.
+ * @param coord Coordinates to convert.
+ * @param screen_width Width of the screen. Can be NULL to use the default value for the top screen.
+ * @param screen_height Height of the screen. Can be NULL to use the default value for the top screen.
+ * @param x Pointer to output the screen X coordinate to.
+ * @param y Pointer to output the screen Y coordinate to.
+ */
+Result qtmConvertCoordToScreen(qtmHeadtrackingInfoCoord *coord, float *screen_width, float *screen_height, u32 *x, u32 *y);
 

--- a/libctru/include/3ds/vram.h
+++ b/libctru/include/3ds/vram.h
@@ -1,8 +1,43 @@
+/**
+ * @file vram.h
+ * @brief VRAM allocator.
+ */
 #pragma once
 
 // Functions for allocating/deallocating VRAM
-void* vramAlloc(size_t size); // returns a 16-byte aligned address
+
+/**
+ * @brief Allocates a 0x80-byte aligned buffer.
+ * @param size Size of the buffer to allocate.
+ * @return The allocated buffer.
+ */
+void* vramAlloc(size_t size);
+
+/**
+ * @brief Allocates a buffer aligned to the given size.
+ * @param size Size of the buffer to allocate.
+ * @param alignment Alignment to use.
+ * @return The allocated buffer.
+ */
 void* vramMemAlign(size_t size, size_t alignment);
-void* vramRealloc(void* mem, size_t size); // not implemented yet
+
+/**
+ * @brief Reallocates a buffer.
+ * Note: Not implemented yet.
+ * @param mem Buffer to reallocate.
+ * @param size Size of the buffer to allocate.
+ * @return The reallocated buffer.
+ */
+void* vramRealloc(void* mem, size_t size);
+
+/**
+ * @brief Frees a buffer.
+ * @param mem Buffer to free.
+ */
 void vramFree(void* mem);
-u32 vramSpaceFree(void); // get free VRAM space in bytes
+
+/**
+ * @brief Gets the current VRAM free space.
+ * @return The current VRAM free space.
+ */
+u32 vramSpaceFree(void);


### PR DESCRIPTION
This PR rewrites most of the ctrulib documentation to be consistent with the established doxygen format. It is targeted towards the great-refactor branch.

Let me know if there are any issues with the rewritten documentation.