### PR TITLE
Allow documentation for static functions

### DIFF
--- a/libctru/Doxyfile
+++ b/libctru/Doxyfile
@@ -416,7 +416,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO


### PR DESCRIPTION
This will show static functions such as the ones in the ipc.h header in the documentation.