### PR TITLE
Travis ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 Thumbs.db
 build/
 lib/
+docs/
+internal_docs
 build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: c
+
+sudo: false
+
+#Cache devkitArm and doxygen
+cache:
+  directories:
+    - /home/travis/devkitPro
+    - /home/travis/doxygen/doxygen-1.8.10/bin
+
+before_install:
+  # Travis has an OLD doxygen build, so we fetch a recent one
+  - export DOXY_BINPATH=/home/travis/doxygen/doxygen-1.8.10/bin
+  - if [ ! -e "$DOXY_BINPATH/doxygen" ]; then mkdir -p ~/doxygen && cd ~/doxygen; fi
+  - if [ ! -e "$DOXY_BINPATH/doxygen" ]; then wget http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.10.linux.bin.tar.gz; fi
+  - if [ ! -e "$DOXY_BINPATH/doxygen" ]; then tar xzf doxygen-1.8.10.linux.bin.tar.gz; fi
+  - export PATH=$PATH:$DOXY_BINPATH
+  # Prepare devkitArm update
+  - export DEVKITPRO=/home/travis/devkitPro
+  - export DEVKITARM=${DEVKITPRO}/devkitARM
+  - mkdir -p $DEVKITPRO
+  - cd $DEVKITPRO
+  - wget -N http://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl
+  - 
+
+install:
+  - cd $DEVKITPRO
+  # Install or update devkitArm if it's cached
+  - perl devkitARMupdate.pl
+  - cd $TRAVIS_BUILD_DIR
+  
+env:
+  global:
+    - secure: "ENCRYPTED GH_TOKEN HERE"
+  
+script:
+  - cd $TRAVIS_BUILD_DIR/libctru
+  - make
+  
+  
+after_success:
+  - cd $TRAVIS_BUILD_DIR
+  - #Build the doxygen files and upload to GH pages
+  - git config --global user.email "travis@travis-ci.org"
+  - git config --global user.name "TravisCI-DocBuilder"
+  # Build the doxygen documentation and push it to gh-pages if current branch is great-refactor
+  - sh exportdoc.sh

--- a/exportdoc.sh
+++ b/exportdoc.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ "$TRAVIS_REPO_SLUG" = "smealum/ctrulib" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "great-refactor" ]; then
+git clone --branch=gh-pages --single-branch --depth 1 https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG docs
+git rm -rf docs/*
+cd libctru
+doxygen Doxyfile
+mv ./docs/html/* ../docs
+cd ../docs
+git add --all
+git commit -m"Doc generated from commit $TRAVIS_COMMIT"
+git push -f origin gh-pages
+
+fi

--- a/libctru/Doxyfile
+++ b/libctru/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "libctru"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = "$(TRAVIS_BRANCH) $(TRAVIS_COMMIT)"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -743,7 +743,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = source include
+INPUT                  = source include ../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -879,7 +879,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = ../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing


### PR DESCRIPTION
Main purpose is to build and publish the documentation automatically, but it will also check if nothing broke by compiling with the latest devkitArm.

The "ENCRYPTED GH_TOKEN HERE" has to be replaced with an encrypted OAuth token so that Travis can push to the repository.

line 2 of exportdoc.sh will need to be changed when merging great-refactor into master, so that the documentation will build for master and not great-refactor. (and also the comment at line 46 of .travis.yml)
