### PR TITLE
Fix MIC cutting off a second of audio.

### DIFF
--- a/examples/audio/mic/source/main.c
+++ b/examples/audio/mic/source/main.c
@@ -59,7 +59,7 @@ int main()
 				if(R_FAILED(CSND_UpdateInfo(0))) printf("Failed to stop audio playback.\n");
 
 				printf("Starting sampling...\n");
-				if(R_SUCCEEDED(MICU_SetPower(true)) && R_SUCCEEDED(MICU_StartSampling(MICU_ENCODING_PCM16_SIGNED, MICU_SAMPLE_RATE_16360, 0, micbuf_datasize, true))) printf("Now recording.\n");
+				if(R_SUCCEEDED(MICU_StartSampling(MICU_ENCODING_PCM16_SIGNED, MICU_SAMPLE_RATE_16360, 0, micbuf_datasize, true))) printf("Now recording.\n");
 				else printf("Failed to start sampling.\n");
 			}
 
@@ -78,7 +78,7 @@ int main()
 			if(hidKeysUp() & KEY_A)
 			{
 				printf("Stoping sampling...\n");
-				if(R_FAILED(MICU_StopSampling()) || R_FAILED(MICU_SetPower(false))) printf("Failed to stop sampling.\n");
+				if(R_FAILED(MICU_StopSampling())) printf("Failed to stop sampling.\n");
 
 				printf("Starting audio playback...\n");
 				if(R_SUCCEEDED(GSPGPU_FlushDataCache(audiobuf, audiobuf_pos)) && R_SUCCEEDED(csndPlaySound(0x8, SOUND_ONE_SHOT | SOUND_FORMAT_16BIT, 16360, 1.0, 0.0, (u32*)audiobuf, NULL, audiobuf_pos))) printf("Now playing.\n");

--- a/libctru/source/services/mic.c
+++ b/libctru/source/services/mic.c
@@ -30,6 +30,9 @@ Result micInit(u8* buffer, u32 bufferSize)
 	if (R_FAILED(ret)) goto end;
 
 	ret = MICU_MapSharedMem(micSharedMemSize, micSharedMemHandle);
+	if (R_FAILED(ret)) goto end;
+
+	ret = MICU_SetPower(true);
 end:
 	if (R_FAILED(ret)) micExit();
 	return ret;
@@ -46,8 +49,9 @@ void micExit(void)
 		micSharedMemHandle = 0;
 	}
 
-	if(micHandle)
+	if (micHandle)
 	{
+		MICU_SetPower(false);
 		svcCloseHandle(micHandle);
 		micHandle = 0;
 	}


### PR DESCRIPTION
Fixes the issue where the MIC example (and likely other uses of MIC) cut off the first second of audio.