### PR TITLE
AM: implement external title database IPC functions

### DIFF
--- a/libctru/include/3ds/services/am.h
+++ b/libctru/include/3ds/services/am.h
@@ -112,3 +112,15 @@ Result AM_GetTitleProductCode(u8 mediatype, u64 titleID, char* productCode);
  * @param fileHandle Handle of the CIA file to read.
  */
 Result AM_GetCiaFileInfo(u8 mediatype, AM_TitleEntry *titleEntry, Handle fileHandle);
+
+/**
+ * @brief Initializes the external (SD) title database.
+ * @param overwrite Overwrites the database if it already exists.
+ */
+Result AM_InitializeExternalTitleDatabase(bool overwrite);
+
+/**
+ * @brief Queries whether the external title database is available.
+ * @param[out] available Pointer to output the availability status to.
+ */
+Result AM_QueryAvailableExternalTitleDatabase(bool* available);

--- a/libctru/source/services/am.c
+++ b/libctru/source/services/am.c
@@ -233,3 +233,34 @@ Result AM_GetCiaFileInfo(u8 mediatype, AM_TitleEntry *titleEntry, Handle fileHan
 
 	return (Result)cmdbuf[1];
 }
+
+Result AM_InitializeExternalTitleDatabase(bool overwrite)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x18,2,0); // 0x180080
+	cmdbuf[1] = 1; // No other media type is accepted
+	cmdbuf[2] = overwrite;
+
+	if(R_FAILED(ret = svcSendSyncRequest(amHandle))) return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result AM_QueryAvailableExternalTitleDatabase(bool* available)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x19,1,0); // 0x190040
+	cmdbuf[1] = 1; // No other media type is accepted
+
+	if(R_FAILED(ret = svcSendSyncRequest(amHandle))) return ret;
+	if(R_FAILED(ret = (Result)cmdbuf[1])) return ret;
+
+	// Only accept this if the command was a success
+	if(available) *available = cmdbuf[2];
+
+	return ret;
+}


### PR DESCRIPTION
Correct use of these functions allows applications that require the external (SD) title database (e.g. title managers) to check if it exists, and if not, have it created. These are also used by eShop.
