### PR TITLE
Add __sync_get_arbiter.

### DIFF
--- a/libctru/include/3ds/synchronization.h
+++ b/libctru/include/3ds/synchronization.h
@@ -60,6 +60,12 @@ static inline bool __strex(s32* addr, s32 val)
 #define AtomicSwap(ptr, value) __atomic_exchange_n((u32*)(ptr), (value), __ATOMIC_SEQ_CST)
 
 /**
+ * @brief Retrieves the synchronization subsystem's address arbiter handle.
+ * @return The synchronization subsystem's address arbiter handle.
+ */
+Handle __sync_get_arbiter(void);
+
+/**
  * @brief Initializes a light lock.
  * @param lock Pointer to the lock.
  */

--- a/libctru/source/synchronization.c
+++ b/libctru/source/synchronization.c
@@ -16,6 +16,11 @@ void __sync_fini(void)
 		svcCloseHandle(arbiter);
 }
 
+Handle __sync_get_arbiter(void)
+{
+	return arbiter;
+}
+
 void LightLock_Init(LightLock* lock)
 {
 	do


### PR DESCRIPTION
Allows retrieving the synchronization subsystem's address arbiter handle, as creating another does not seem to work. ("out of resource" error)