### PR TITLE
fix thread static buffers usage (save+restore)

### DIFF
--- a/libctru/source/services/dsp.c
+++ b/libctru/source/services/dsp.c
@@ -148,11 +148,13 @@ Result DSP_ReadPipeIfPossible(u32 channel, u32 peer, void* buffer, u16 length, u
 	staticbufs[0] = IPC_Desc_StaticBuffer(length,0);
 	staticbufs[1] = (u32)buffer;
 
-	if (R_FAILED(ret = svcSendSyncRequest(dspHandle))) return ret;
+	ret = svcSendSyncRequest(dspHandle);
 
 	staticbufs[0] = saved1;
 	staticbufs[1] = saved2;
-
+	
+	if (R_FAILED(ret)) return ret;
+	
 	if (length_read)
 		*length_read = cmdbuf[2] & 0xFFFF;
 	return cmdbuf[1];

--- a/libctru/source/services/soc/soc_accept.c
+++ b/libctru/source/services/soc/soc_accept.c
@@ -50,14 +50,15 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	staticbufs[1] = (u32)tmpaddr;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+	
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+	
 	if(ret != 0) {
 		__release_handle(fd);
 		errno = SYNC_ERROR;
 		return ret;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)

--- a/libctru/source/services/soc/soc_gethostbyname.c
+++ b/libctru/source/services/soc/soc_gethostbyname.c
@@ -30,13 +30,14 @@ struct hostent* gethostbyname(const char *name)
 	staticbufs[1] = (u32)outbuf;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+
 	if(ret != 0) {
 		h_errno = NO_RECOVERY;
 		return NULL;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)

--- a/libctru/source/services/soc/soc_getpeername.c
+++ b/libctru/source/services/soc/soc_getpeername.c
@@ -29,13 +29,14 @@ int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	staticbufs[1] = (u32)tmpaddr;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+	
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+	
 	if(ret != 0) {
 		errno = SYNC_ERROR;
 		return ret;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)

--- a/libctru/source/services/soc/soc_getsockname.c
+++ b/libctru/source/services/soc/soc_getsockname.c
@@ -29,13 +29,14 @@ int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	staticbufs[1] = (u32)tmpaddr;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+
 	if(ret != 0) {
 		errno = SYNC_ERROR;
 		return ret;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)

--- a/libctru/source/services/soc/soc_getsockopt.c
+++ b/libctru/source/services/soc/soc_getsockopt.c
@@ -30,13 +30,14 @@ int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optl
 	staticbufs[1] = (u32)optval;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+	
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+	
 	if(ret != 0) {
 		errno = SYNC_ERROR;
 		return ret;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)

--- a/libctru/source/services/soc/soc_poll.c
+++ b/libctru/source/services/soc/soc_poll.c
@@ -51,14 +51,15 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	staticbufs[1] = (u32)tmp_fds;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+	
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+	
 	if(ret != 0) {
 		free(tmp_fds);
 		errno = SYNC_ERROR;
 		return ret;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)

--- a/libctru/source/services/soc/soc_recvfrom.c
+++ b/libctru/source/services/soc/soc_recvfrom.c
@@ -33,13 +33,14 @@ ssize_t socuipc_cmd7(int sockfd, void *buf, size_t len, int flags, struct sockad
 	staticbufs[1] = (u32)tmpaddr;
 
 	ret = svcSendSyncRequest(SOCU_handle);
+	
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+	
 	if(ret != 0) {
 		errno = SYNC_ERROR;
 		return -1;
 	}
-
-	staticbufs[0] = saved_threadstorage[0];
-	staticbufs[1] = saved_threadstorage[1];
 
 	ret = (int)cmdbuf[1];
 	if(ret == 0)


### PR DESCRIPTION
In case of error, the functions would return before restoring the content of the thread static buffers.
Also added missing save+restore for APT_AppletUtility