### PR TITLE
More soc

### DIFF
--- a/libctru/include/netdb.h
+++ b/libctru/include/netdb.h
@@ -17,6 +17,16 @@ struct hostent {
 	char	*h_addr;
 };
 
+
+#define AI_PASSIVE     0x01
+#define AI_CANONNAME   0x02
+#define AI_NUMERICHOST 0x04
+#define AI_NUMERICSERV 0x00 /* probably 0x08 but services names are never resolved */
+
+// doesn't apply to 3ds
+#define AI_ADDRCONFIG  0x00
+
+
 #define NI_MAXHOST     1025
 #define NI_MAXSERV       32
 
@@ -31,6 +41,16 @@ struct hostent {
 #define EAI_NONAME   (-305)
 #define EAI_SOCKTYPE (-307)
 
+struct addrinfo {
+	int             ai_flags;
+	int             ai_family;
+	int             ai_socktype;
+	int             ai_protocol;
+	socklen_t       ai_addrlen;
+	char            *ai_canonname;
+	struct sockaddr *ai_addr;
+	struct addrinfo *ai_next;
+};
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +65,12 @@ extern "C" {
 	int getnameinfo(const struct sockaddr *sa, socklen_t salen,
 		char *host, socklen_t hostlen,
 		char *serv, socklen_t servlen, int flags);
+
+	int getaddrinfo(const char *node, const char *service,
+		const struct addrinfo *hints,
+		struct addrinfo **res);
+
+	void freeaddrinfo(struct addrinfo *ai);
 
 #ifdef __cplusplus
 }

--- a/libctru/include/netdb.h
+++ b/libctru/include/netdb.h
@@ -17,6 +17,21 @@ struct hostent {
 	char	*h_addr;
 };
 
+#define NI_MAXHOST     1025
+#define NI_MAXSERV       32
+
+#define NI_NOFQDN      0x01
+#define NI_NUMERICHOST 0x02
+#define NI_NAMEREQD    0x04
+#define NI_NUMERICSERV 0x00 /* probably 0x08 but services names are never resolved */
+#define NI_DGRAM       0x00 /* probably 0x10 but services names are never resolved */
+
+#define EAI_FAMILY   (-303)
+#define EAI_MEMORY   (-304)
+#define EAI_NONAME   (-305)
+#define EAI_SOCKTYPE (-307)
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -26,6 +41,10 @@ extern "C" {
 	struct hostent*	gethostbyaddr(const void *addr, socklen_t len, int type);
 	void		herror(const char *s);
 	const char*	hstrerror(int err);
+
+	int getnameinfo(const struct sockaddr *sa, socklen_t salen,
+		char *host, socklen_t hostlen,
+		char *serv, socklen_t servlen, int flags);
 
 #ifdef __cplusplus
 }

--- a/libctru/include/netdb.h
+++ b/libctru/include/netdb.h
@@ -72,6 +72,7 @@ extern "C" {
 
 	void freeaddrinfo(struct addrinfo *ai);
 
+	const char *gai_strerror(int ecode);
 #ifdef __cplusplus
 }
 #endif

--- a/libctru/include/sys/socket.h
+++ b/libctru/include/sys/socket.h
@@ -7,7 +7,7 @@
 
 #define PF_UNSPEC	0
 #define PF_INET		2
-#define PF_INET6	10
+#define PF_INET6	23
 
 #define AF_UNSPEC	PF_UNSPEC
 #define AF_INET		PF_INET

--- a/libctru/include/sys/socket.h
+++ b/libctru/include/sys/socket.h
@@ -60,9 +60,10 @@ struct sockaddr {
 	char		sa_data[];
 };
 
+// biggest size on 3ds is 0x1C (sockaddr_in6)
 struct sockaddr_storage {
 	sa_family_t	ss_family;
-	char		__ss_padding[14];
+	char		__ss_padding[26];
 };
 
 struct linger {

--- a/libctru/source/services/soc/soc_gai_strerror.c
+++ b/libctru/source/services/soc/soc_gai_strerror.c
@@ -1,0 +1,18 @@
+#include <netdb.h>
+
+const char *gai_strerror(int ecode)
+{
+	switch(ecode)
+	{
+		case EAI_FAMILY :
+			return "ai_family not supported";
+		case EAI_MEMORY :
+			return "Memory allocation failure";
+		case EAI_NONAME :
+			return "Name or service not known";
+		case EAI_SOCKTYPE :
+			return "ai_socktype not supported";
+		default:
+			return "Unknown error";
+	}
+}

--- a/libctru/source/services/soc/soc_getaddrinfo.c
+++ b/libctru/source/services/soc/soc_getaddrinfo.c
@@ -1,0 +1,162 @@
+#include "soc_common.h"
+#include <netdb.h>
+#include <3ds/ipc.h>
+#include <3ds/result.h>
+#include <stdlib.h>
+
+#define DEFAULT_NUM_ADDRINFO 4
+
+typedef struct addrinfo_3ds_t addrinfo_3ds_t;
+struct addrinfo_3ds_t
+{
+	s32                     ai_flags;
+	s32                     ai_family;
+	s32                     ai_socktype;
+	s32                     ai_protocol;
+	u32                     ai_addrlen;
+	char                    ai_canonname[256];
+	struct sockaddr_storage ai_addr;
+};
+
+void freeaddrinfo(struct addrinfo *ai)
+{
+	struct addrinfo *next_ai = ai;
+	while(ai != NULL)
+	{
+		next_ai = ai->ai_next;
+		free(ai);
+		ai = next_ai;
+	}
+}
+
+static struct addrinfo * buffer2addrinfo(addrinfo_3ds_t * entry)
+{
+	int ai_canonname_len = strnlen(entry->ai_canonname, sizeof(entry->ai_canonname));
+	struct addrinfo *ai;
+	size_t          len = sizeof(*ai)
+	                    + sizeof(struct sockaddr_storage)
+	                    + ai_canonname_len
+	                    + 1;
+
+	ai = (struct addrinfo*)calloc(1,len);
+	if(ai != NULL)
+	{
+		ai->ai_canonname = (char*)ai + sizeof(*ai) + sizeof(struct sockaddr_storage);
+		ai->ai_addr      = (struct sockaddr*)((char*)ai + sizeof(*ai));
+
+		ai->ai_flags    = entry->ai_flags;
+		ai->ai_family   = entry->ai_family;
+		ai->ai_socktype = entry->ai_socktype;
+		ai->ai_protocol = entry->ai_protocol;
+		ai->ai_addrlen  = entry->ai_addrlen;
+
+		memcpy(ai->ai_canonname, entry->ai_canonname, ai_canonname_len);
+		memcpy(ai->ai_addr, &entry->ai_addr, ai->ai_addrlen);
+	}
+	return ai;
+}
+
+
+static int getaddrinfo_detail(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res, addrinfo_3ds_t *info, s32 info_count, s32 * count)
+{
+	int            i;
+	u32            *cmdbuf = getThreadCommandBuffer();
+	u32            saved_threadstorage[2];
+
+	if(node == NULL && service == NULL)
+	{
+		return EAI_NONAME;
+	}
+
+	cmdbuf[ 0] = IPC_MakeHeader(0xF,4,6); // 0x00F0106
+	cmdbuf[ 1] = node    == NULL ? 0 : strlen(node)+1;
+	cmdbuf[ 2] = service == NULL ? 0 : strlen(service)+1;
+	cmdbuf[ 3] = hints   == NULL ? 0 : sizeof(*hints);
+	cmdbuf[ 4] = sizeof(addrinfo_3ds_t) * info_count;
+	cmdbuf[ 5] = IPC_Desc_StaticBuffer(cmdbuf[1], 5);
+	cmdbuf[ 6] = (u32)node;
+	cmdbuf[ 7] = IPC_Desc_StaticBuffer(cmdbuf[2], 6);
+	cmdbuf[ 8] = (u32)service;
+	cmdbuf[ 9] = IPC_Desc_StaticBuffer(cmdbuf[3], 7);
+	cmdbuf[10] = (u32)hints;
+
+	u32 * staticbufs = getThreadStaticBuffers();
+
+	// Save the thread storage values
+	for(i = 0 ; i < 2 ; ++i)
+		saved_threadstorage[i] = staticbufs[i];
+
+	staticbufs[0] = IPC_Desc_StaticBuffer(sizeof(addrinfo_3ds_t) * info_count, 0);
+	staticbufs[1] = (u32)info;
+
+	int ret = svcSendSyncRequest(SOCU_handle);
+
+	// Restore the thread storage values
+	for(i = 0 ; i < 2 ; ++i)
+		staticbufs[i] = saved_threadstorage[i];
+
+	if(R_FAILED(ret)) {
+		errno = SYNC_ERROR;
+		return ret;
+	}
+
+	ret = cmdbuf[1];
+	if(R_FAILED(ret)) {
+		errno = SYNC_ERROR;
+		return ret;
+	}
+	if(cmdbuf[2] != 0)
+	{
+		return cmdbuf[2];
+	}
+
+	*count = cmdbuf[3];
+	if(*count <= 0)
+		*res = NULL;
+	else if(*count <= info_count)
+	{
+		struct addrinfo **ptr = res;
+		for(i = 0; i < *count; ++i)
+		{
+			*ptr = buffer2addrinfo(&info[i]);
+			if(*ptr == NULL)
+			{
+				freeaddrinfo(*res);
+				*res = NULL;
+				return EAI_MEMORY;
+			}
+			ptr = &(*ptr)->ai_next;
+		}
+		*ptr = NULL;
+	}
+
+	return 0;
+}
+
+int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res)
+{
+	Result ret;
+	addrinfo_3ds_t *info = NULL, *tmp;
+	s32            count = DEFAULT_NUM_ADDRINFO, info_count;
+	
+	if(node == NULL && service == NULL)
+	{
+		return EAI_NONAME;
+	}
+
+	do
+	{
+		info_count = count;
+		tmp = (addrinfo_3ds_t*)realloc(info, sizeof(addrinfo_3ds_t) * info_count);
+		if(tmp == NULL)
+		{
+			free(info);
+			return EAI_MEMORY;
+		}
+		info = tmp;
+		ret = getaddrinfo_detail(node,service,hints,res,info,info_count,&count);
+	} while(count > info_count && R_SUCCEEDED(ret));
+
+	free(info);
+	return ret;
+}

--- a/libctru/source/services/soc/soc_getnameinfo.c
+++ b/libctru/source/services/soc/soc_getnameinfo.c
@@ -1,0 +1,68 @@
+#include "soc_common.h"
+#include <netdb.h>
+#include <3ds/ipc.h>
+#include <3ds/result.h>
+
+int getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t hostlen, char *serv, socklen_t servlen, int flags)
+{
+	int i,tmp_addrlen;
+	u32 *cmdbuf = getThreadCommandBuffer();
+	u32 saved_threadstorage[4];
+	u8 tmpaddr[0x1c]; // sockaddr size for the kernel is 0x1C (sockaddr_in6?)
+
+	if((host == NULL || hostlen == 0) && (serv == NULL || servlen == 0))
+	{
+		return EAI_NONAME;
+	}
+
+	if(sa->sa_family == AF_INET)
+		tmp_addrlen = 8;
+	else
+		tmp_addrlen = 0x1c;
+
+	if(salen < tmp_addrlen) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	tmpaddr[0] = tmp_addrlen;
+	tmpaddr[1] = sa->sa_family;
+	memcpy(&tmpaddr[2], &sa->sa_data, tmp_addrlen-2);
+
+	cmdbuf[0] = IPC_MakeHeader(0x10,4,2); // 0x100102
+	cmdbuf[1] = sizeof(tmpaddr);
+	cmdbuf[2] = hostlen;
+	cmdbuf[3] = servlen;
+	cmdbuf[4] = flags;
+	cmdbuf[5] = IPC_Desc_StaticBuffer(sizeof(tmpaddr),8);
+	cmdbuf[6] = (u32)tmpaddr;
+
+	u32 * staticbufs = getThreadStaticBuffers();
+
+	// Save the thread storage values
+	for(i = 0 ; i < 4 ; ++i)
+		saved_threadstorage[i] = staticbufs[i];
+
+	staticbufs[0] = IPC_Desc_StaticBuffer(hostlen,0);
+	staticbufs[1] = (u32)host;
+	staticbufs[2] = IPC_Desc_StaticBuffer(servlen,0);
+	staticbufs[3] = (u32)serv;
+
+	Result ret = svcSendSyncRequest(SOCU_handle);
+
+	// Restore the thread storage values
+	for(i = 0 ; i < 4 ; ++i)
+		staticbufs[i] = saved_threadstorage[i];
+
+	if(R_FAILED(ret)) {
+		errno = SYNC_ERROR;
+		return ret;
+	}	
+
+	ret = cmdbuf[1];
+	if(R_FAILED(ret)) {
+		errno = SYNC_ERROR;
+		return ret;
+	}
+	return cmdbuf[2];
+}


### PR DESCRIPTION
The following PR adds support for getaddrinfo and getnameinfo.
Note that the PF_INET6 value was checked thanks to genameinfo, which allows IPv6 DNS reverse lookup, but sockaddr_in6 wasn't added since it would lead people to think it works with other functions such as 'socket'.
Some EAI_* error codes are missing but I couldn't produce any other value.

Thanks to @mtheall for his help !