### PR TITLE
fix getaddrinfo

### DIFF
--- a/libctru/source/services/soc/soc_getaddrinfo.c
+++ b/libctru/source/services/soc/soc_getaddrinfo.c
@@ -1,5 +1,6 @@
 #include "soc_common.h"
 #include <netdb.h>
+#include <arpa/inet.h>
 #include <3ds/ipc.h>
 #include <3ds/result.h>
 #include <stdlib.h>
@@ -52,6 +53,7 @@ static struct addrinfo * buffer2addrinfo(addrinfo_3ds_t * entry)
 
 		memcpy(ai->ai_canonname, entry->ai_canonname, ai_canonname_len);
 		memcpy(ai->ai_addr, &entry->ai_addr, ai->ai_addrlen);
+		ai->ai_addr->sa_family = ntohs(ai->ai_addr->sa_family) & 0xFF; // Clear sa_len to match the API
 	}
 	return ai;
 }


### PR DESCRIPTION
sa_family of the ai_addr member wasn't converted back to the host format.