### PR TITLE
added gethostname

### DIFF
--- a/libctru/include/3ds/services/soc.h
+++ b/libctru/include/3ds/services/soc.h
@@ -20,12 +20,15 @@ Result socInit(u32 *context_addr, u32 context_size);
  */
 Result socExit(void);
 
-// this is supposed to be in unistd.h but newlib only puts it for cygwin
+// this is supposed to be in unistd.h but newlib only puts it for cygwin, waiting for newlib patch from dkA
 /**
  * @brief Gets the system's host ID.
  * @return The system's host ID.
  */
 long gethostid(void);
+
+// this is supposed to be in unistd.h but newlib only puts it for cygwin, waiting for newlib patch from dkA
+int gethostname(char *name, size_t namelen);
 
 int SOCU_ShutdownSockets();
 

--- a/libctru/source/services/soc/soc_gethostname.c
+++ b/libctru/source/services/soc/soc_gethostname.c
@@ -1,0 +1,14 @@
+#include <arpa/inet.h>
+#include <3ds/result.h>       // To be removed when dkA patch to newlib is applied
+#include <3ds/services/soc.h> // To be changed to unistd.h when dkA patch to newlib is applied
+
+
+// The 3DS doesn't give any host name for its own IP through gethostbyaddr
+// For compatibility, the host ASCII name will be given (IPv4 dotted notation)
+int gethostname(char *name, size_t namelen)
+{
+	long hostid = gethostid();
+	const char * hostname = inet_ntop(AF_INET,&hostid,name,namelen);
+	if(hostname == NULL)return -1;
+	return 0;
+}


### PR DESCRIPTION
This commit adds gethostname by returning the IPv4 dotted notation. This was chosen so that other machines can still use it as host name with getaddrinfo and gethostbyname.

Note that gethostname and gethostid should in reality be declared in unistd.h, and that an upcoming update of devkitARM will fix this.