### PR TITLE
Change protocol in socket() to 0 if appropriate - Fix #250

### DIFF
--- a/libctru/source/services/soc/soc_socket.c
+++ b/libctru/source/services/soc/soc_socket.c
@@ -11,6 +11,15 @@ int socket(int domain, int type, int protocol)
 	__handle *handle;
 	u32 *cmdbuf = getThreadCommandBuffer();
 
+	// The protocol on the 3DS *must* be 0 to work
+	// To that end, when appropriate, we will make the change for the user
+	if (domain == AF_INET && type == SOCK_STREAM && protocol == 6) {
+		protocol = 0; // TCP is the only option, so 0 will work as expected
+	}
+	if (domain == AF_INET && type == SOCK_DGRAM && protocol == 17) {
+		protocol = 0; // UDP is the only option, so 0 will work as expected
+	}
+
 	cmdbuf[0] = IPC_MakeHeader(0x2,3,2); // 0x200C2
 	cmdbuf[1] = domain;
 	cmdbuf[2] = type;


### PR DESCRIPTION
When the user is specifying TCP or UDP and it is the only option,
change the protocol parameter to 0, which is the only value the
underlying 3DS system will accept as valid. This compatibility layer
ensures that code will work transparently whether on a host system
or the 3DS.