### PR TITLE
Added ld flags for link time optimizations and separating data sections

### DIFF
--- a/libctru/Makefile
+++ b/libctru/Makefile
@@ -42,9 +42,9 @@ INCLUDES	:=	include
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -Wall -Werror -O2 -mword-relocations \
-			-ffunction-sections -fno-strict-aliasing \
-			-fomit-frame-pointer \
+CFLAGS	:=	-g -Wall -Werror -Os -mword-relocations \
+			-flto -ffunction-sections -fdata-sections \
+			-fno-strict-aliasing -fomit-frame-pointer \
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS


### PR DESCRIPTION
For anyone who has size constraints on their output binaries, adding these made my executable 28KB -> 26KB. Not a lot, but it helps. -fdata-sections currently does not do anything, but it doesn't hurt to have the option there.