### PR TITLE
httpc fixes and extensions

### DIFF
--- a/libctru/include/3ds/services/httpc.h
+++ b/libctru/include/3ds/services/httpc.h
@@ -10,6 +10,15 @@ typedef struct {
 	u32 httphandle;    ///< HTTP handle.
 } httpcContext;
 
+/// HTTP request method.
+typedef enum {
+	HTTPC_METHOD_GET = 0x1,
+	HTTPC_METHOD_POST = 0x2,
+	HTTPC_METHOD_HEAD = 0x3,
+	HTTPC_METHOD_PUT = 0x4,
+	HTTPC_METHOD_DELETE = 0x5
+} HTTPC_RequestMethod;
+
 /// HTTP request status.
 typedef enum {
 	HTTPC_STATUS_REQUEST_IN_PROGRESS = 0x5, ///< Request in progress.
@@ -18,6 +27,9 @@ typedef enum {
 
 /// Result code returned when a download is pending.
 #define HTTPC_RESULTCODE_DOWNLOADPENDING 0xd840a02b
+
+// Result code returned when asked about a non-existing header
+#define HTTPC_RESULTCODE_NOTFOUND 0xd840a028
 
 /// Initializes HTTPC.
 Result httpcInit(void);
@@ -31,7 +43,7 @@ void httpcExit(void);
  * @param url URL to connect to.
  * @param use_defaultproxy Whether the default proxy should be used (0 for default)
  */
-Result httpcOpenContext(httpcContext *context, char* url, u32 use_defaultproxy);
+Result httpcOpenContext(httpcContext *context, HTTPC_RequestMethod method, char* url, u32 use_defaultproxy);
 
 /**
  * @brief Closes a HTTP context.
@@ -124,7 +136,7 @@ Result HTTPC_InitializeConnectionSession(Handle handle, Handle contextHandle);
  * @param url URL to connect to.
  * @param contextHandle Pointer to output the created HTTP context handle to.
  */
-Result HTTPC_CreateContext(Handle handle, char* url, Handle* contextHandle);
+Result HTTPC_CreateContext(Handle handle, HTTPC_RequestMethod method, char* url, Handle* contextHandle);
 
 /**
  * @brief Closes a HTTP context.


### PR DESCRIPTION
httpcDownloadData() re-implemented to allow chunked encoding
Identified meaning of HTTPC_CreateContext's cmdbuf[2]
comment the use of the request type
httpcOpenContext now takes an HTTPC_RequestMethod parameter

Signed-off-by: Dave Murphy <davem@devkitpro.org>