### PR TITLE
fix hid:GetGyroscopeRawToDpsCoefficient

### DIFF
--- a/libctru/source/services/hid.c
+++ b/libctru/source/services/hid.c
@@ -286,7 +286,7 @@ Result HIDUSER_GetGyroscopeRawToDpsCoefficient(float *coeff)
 	Result ret=0;
 	if(R_FAILED(ret=svcSendSyncRequest(hidHandle)))return ret;
 
-	*coeff = (float)cmdbuf[2];
+	*coeff = *(float*)(cmdbuf+2);
 
 	return cmdbuf[1];
 }


### PR DESCRIPTION
I think this is what it supposed to be, or you just get some very large number.