### PR TITLE
httpcSetSSLOpt support

### DIFF
--- a/libctru/include/3ds/services/httpc.h
+++ b/libctru/include/3ds/services/httpc.h
@@ -130,6 +130,13 @@ Result httpcGetResponseHeader(httpcContext *context, char* name, char* value, u3
 Result httpcAddTrustedRootCA(httpcContext *context, u8 *cert, u32 certsize);
 
 /**
+ * @brief Sets SSL options for the context.
+ * @param contect Context to set flags on.
+ * @param options SSL option flags.
+ */
+Result httpcSetSSLOpt(httpcContext *context, u32 options);
+
+/**
  * @brief Downloads data from the HTTP context into a buffer.
  * The *entire* content must be downloaded before using httpcCloseContext(), otherwise httpcCloseContext() will hang.
  * @param context Context to download data from.
@@ -268,4 +275,12 @@ Result HTTPC_GetResponseStatusCode(Handle handle, Handle contextHandle, u32* out
  * @param certsize Size of the DER cert.
  */
 Result HTTPC_AddTrustedRootCA(Handle handle, Handle contextHandle, u8 *cert, u32 certsize);
+
+/**
+ * @brief Sets SSL options for the context.
+ * @param handle HTTPC service handle to use.
+ * @param contextHandle HTTP context handle to use.
+ * @param options SSL option flags.
+ */
+Result HTTPC_SetSSLOpt(Handle handle, Handle contextHandle, u32 options);
 

--- a/libctru/include/3ds/services/httpc.h
+++ b/libctru/include/3ds/services/httpc.h
@@ -131,6 +131,7 @@ Result httpcAddTrustedRootCA(httpcContext *context, u8 *cert, u32 certsize);
 
 /**
  * @brief Sets SSL options for the context.
+ * The HTTPC SSL option bits are the same as those defined in sslc.h
  * @param contect Context to set flags on.
  * @param options SSL option flags.
  */

--- a/libctru/source/services/httpc.c
+++ b/libctru/source/services/httpc.c
@@ -169,6 +169,11 @@ Result httpcAddTrustedRootCA(httpcContext *context, u8 *cert, u32 certsize)
 	return HTTPC_AddTrustedRootCA(context->servhandle, context->httphandle, cert, certsize);
 }
 
+Result httpcSetSSLOpt(httpcContext *context, u32 options)
+{
+	return HTTPC_SetSSLOpt(context->servhandle, context->httphandle, options);
+}
+
 Result httpcDownloadData(httpcContext *context, u8* buffer, u32 size, u32 *downloadedsize)
 {
 	Result ret=0;
@@ -460,3 +465,16 @@ Result HTTPC_AddTrustedRootCA(Handle handle, Handle contextHandle, u8 *cert, u32
 	return cmdbuf[1];
 }
 
+Result HTTPC_SetSSLOpt(Handle handle, Handle contextHandle, u32 options)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x2B,2,0); // 0x2B0080
+	cmdbuf[1]=contextHandle;
+	cmdbuf[2]=options;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(handle)))return ret;
+
+	return cmdbuf[1];
+}


### PR DESCRIPTION
These are the HTTP:C SetSSLOpt functions, bit 1<<9 disables SSL certificate checks.