### PR TITLE
Separate information required to open an archive from the actual opened handle.

### DIFF
--- a/libctru/source/internal.h
+++ b/libctru/source/internal.h
@@ -26,7 +26,6 @@ typedef struct
 	// FS session override
 	u32    fs_magic;
 	Handle fs_session;
-	bool   fs_sdmc;
 } ThreadVars;
 
 static inline ThreadVars* getThreadVars(void)

--- a/libctru/source/ndsp/ndsp.c
+++ b/libctru/source/ndsp/ndsp.c
@@ -398,10 +398,10 @@ static bool ndspFindAndLoadComponent(void)
 	do
 	{
 		static const char dsp_filename[] = "/3ds/dspfirm.cdc";
-		FS_Archive arch = { ARCHIVE_SDMC, { PATH_EMPTY, 1, (u8*)"" }, 0 };
-		FS_Path path = { PATH_ASCII, sizeof(dsp_filename), (u8*)dsp_filename };
+		FS_Path archPath = { PATH_EMPTY, 1, (u8*)"" };
+		FS_Path filePath = { PATH_ASCII, sizeof(dsp_filename), (u8*)dsp_filename };
 
-		rc = FSUSER_OpenFileDirectly(&rsrc, arch, path, FS_OPEN_READ, 0);
+		rc = FSUSER_OpenFileDirectly(&rsrc, ARCHIVE_SDMC, archPath, filePath, FS_OPEN_READ, 0);
 		if (R_FAILED(rc)) break;
 
 		u64 size = 0;

--- a/libctru/source/os-versionbin.c
+++ b/libctru/source/os-versionbin.c
@@ -36,13 +36,13 @@ static u32 __CVer_tidlow_regionarray[7] = {
 };
 
 
-static Result __read_versionbin(FS_Archive archive, FS_Path fileLowPath, OS_VersionBin *versionbin)
+static Result __read_versionbin(FS_ArchiveID archiveId, FS_Path archivePath, FS_Path fileLowPath, OS_VersionBin *versionbin)
 {
 	Result ret = 0;
 	Handle filehandle = 0;
 	FILE *f = NULL;
 
-	ret = FSUSER_OpenFileDirectly(&filehandle, archive, fileLowPath, FS_OPEN_READ, 0x0);
+	ret = FSUSER_OpenFileDirectly(&filehandle, archiveId, archivePath, fileLowPath, FS_OPEN_READ, 0x0);
 	if(R_FAILED(ret))return ret;
 
 	ret = romfsInitFromFile(filehandle, 0x0);
@@ -72,16 +72,17 @@ Result osGetSystemVersionData(OS_VersionBin *nver_versionbin, OS_VersionBin *cve
 	u32 archive_lowpath_data[0x10>>2];
 	u32 file_lowpath_data[0x14>>2];
 
-	FS_Archive archive;
+	FS_ArchiveID archiveId;
+	FS_Path archivePath;
 	FS_Path fileLowPath;
 
 	memset(archive_lowpath_data, 0, sizeof(archive_lowpath_data));
 	memset(file_lowpath_data,    0, sizeof(file_lowpath_data));
 
-	archive.id = 0x2345678a;
-	archive.lowPath.type = PATH_BINARY;
-	archive.lowPath.size = 0x10;
-	archive.lowPath.data = archive_lowpath_data;
+	archiveId = 0x2345678a;
+	archivePath.type = PATH_BINARY;
+	archivePath.size = 0x10;
+	archivePath.data = archive_lowpath_data;
 
 	fileLowPath.type = PATH_BINARY;
 	fileLowPath.size = 0x14;
@@ -100,11 +101,11 @@ Result osGetSystemVersionData(OS_VersionBin *nver_versionbin, OS_VersionBin *cve
 	cfguExit();
 
 	archive_lowpath_data[0] = __NVer_tidlow_regionarray[region];
-	ret = __read_versionbin(archive, fileLowPath, nver_versionbin);
+	ret = __read_versionbin(archiveId, archivePath, fileLowPath, nver_versionbin);
 	if(R_FAILED(ret))return ret;
 
 	archive_lowpath_data[0] = __CVer_tidlow_regionarray[region];
-	ret = __read_versionbin(archive, fileLowPath, cver_versionbin);
+	ret = __read_versionbin(archiveId, archivePath, fileLowPath, cver_versionbin);
 	return ret;
 }
 

--- a/libctru/source/sdmc_dev.c
+++ b/libctru/source/sdmc_dev.c
@@ -91,16 +91,7 @@ sdmc_devoptab =
 };
 
 /*! SDMC archive handle */
-static FS_Archive sdmcArchive =
-{
-  .id = ARCHIVE_SDMC,
-  .lowPath =
-  {
-    .type = PATH_EMPTY,
-    .size = 1,
-    .data = (u8*)"",
-  },
-};
+static FS_Archive sdmcArchive;
 
 /*! @endcond */
 
@@ -216,14 +207,17 @@ Result sdmcInit(void)
   ssize_t  units;
   uint32_t code;
   char     *p;
+  FS_Path sdmcPath = { PATH_EMPTY, 1, (u8*)"" };
   Result   rc = 0;
 
   if(sdmcInitialised)
     return rc;
 
-  rc = FSUSER_OpenArchive(&sdmcArchive);
+
+  rc = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, sdmcPath);
   if(R_SUCCEEDED(rc))
   {
+    fsExemptFromSession(sdmcArchive);
 
     int dev = AddDevice(&sdmc_devoptab);
 
@@ -296,9 +290,10 @@ Result sdmcExit(void)
 
   if(!sdmcInitialised) return rc;
 
-  rc = FSUSER_CloseArchive(&sdmcArchive);
+  rc = FSUSER_CloseArchive(sdmcArchive);
   if(R_SUCCEEDED(rc))
   {
+    fsUnexemptFromSession(sdmcArchive);
     RemoveDevice("sdmc:");
     sdmcInitialised = false;
   }


### PR DESCRIPTION
This separates the information required to open an archive from the actual opened handle, making it easier to pass around an opened archive in user code without having to worry about keeping path data, etc. around.

Because it would've been difficult to work this change around, the "sdmc" parameter to fsUseSession was also removed. I could not find any real use for it anyway, as you could easily just switch back to the main session with fsEndUseSession, if needed, to access the SD card.