### PR TITLE
Implement svcBindInterrupt and svcUnbindInterrupt

### DIFF
--- a/libctru/include/3ds/svc.h
+++ b/libctru/include/3ds/svc.h
@@ -821,6 +821,22 @@ Result svcAcceptSession(Handle* session, Handle port);
  * @param replyTarget Handle of the session to reply to.
  */
 Result svcReplyAndReceive(s32* index, Handle* handles, s32 handleCount, Handle replyTarget);
+
+/**
+ * @brief Binds an event handle to an ARM11 interrupt.
+ * @param interruptId Interrupt identfier (see https://www.3dbrew.org/wiki/ARM11_Interrupts).
+ * @param event Event handle to bind to the given interrupt.
+ * @param priority Priority of the interrupt for the current process.
+ * @param isManualClear Indicates whether the interrupt has to be manually cleared or not.
+ */
+Result svcBindInterrupt(u32 interruptId, Handle event, s32 priority, bool isManualClear);
+
+/**
+ * @brief Unbinds an event handle from an ARM11 interrupt.
+ * @param interruptId Interrupt identfier, see (see https://www.3dbrew.org/wiki/ARM11_Interrupts).
+ * @param event Event handle to unbind from the given interrupt.
+ */
+Result svcUnbindInterrupt(u32 interruptId, Handle event);
 ///@}
 
 ///@name Time

--- a/libctru/source/svc.s
+++ b/libctru/source/svc.s
@@ -352,6 +352,14 @@ SVC_BEGIN svcReplyAndReceive
 	add sp, sp, #4
 	bx  lr
 
+SVC_BEGIN svcBindInterrupt
+	svc 0x50
+	bx lr
+
+SVC_BEGIN svcUnbindInterrupt
+	svc 0x51
+	bx lr
+
 SVC_BEGIN svcInvalidateProcessDataCache
 	svc 0x52
 	bx  lr


### PR DESCRIPTION
This commit implements svcBindInterrupt and svcUnbindInterrupt.

This is needed to develop certain applications (such as custom system modules).