### PR TITLE
More err:f changes

### DIFF
--- a/libctru/source/errf.c
+++ b/libctru/source/errf.c
@@ -37,11 +37,11 @@ Handle* errfGetSessionHandle(void)
 	return &errfHandle;
 }
 
-Result ERRF_Throw(ERRF_FatalErrInfo *error)
+Result ERRF_Throw(const ERRF_FatalErrInfo* error)
 {
 	uint32_t *cmdbuf = getThreadCommandBuffer();
 
-	cmdbuf[0] = 0x10800;
+	cmdbuf[0] = IPC_MakeHeader(0x1,32,0); // 0x10800
 	memcpy(&cmdbuf[1], error, sizeof(ERRF_FatalErrInfo));
 
 	Result ret = 0;
@@ -49,4 +49,60 @@ Result ERRF_Throw(ERRF_FatalErrInfo *error)
 		return ret;
 
 	return cmdbuf[1];
+}
+
+static inline void getCommonErrorData(ERRF_FatalErrInfo* error, Result failure)
+{
+	error->resCode = failure;
+	svcGetProcessId(&error->procId, 0xFFFF8001);
+}
+
+Result ERRF_ThrowResult(Result failure)
+{
+	ERRF_FatalErrInfo error;
+	Result ret;
+
+	if (R_FAILED(ret = errfInit()))
+		return ret;
+
+	memset(&error, 0, sizeof(error));
+
+	error.type = ERRF_ERRTYPE_GENERIC;
+
+	// pcAddr is not used by ErrDisp for ERRF_ERRTYPE_FAILURE
+	error.pcAddr = (u32)__builtin_extract_return_addr(__builtin_return_address(0));
+	getCommonErrorData(&error, failure);
+
+	ret = ERRF_Throw(&error);
+
+	errfExit();
+
+	return ret;
+}
+
+Result ERRF_ThrowResultWithMessage(Result failure, const char* message)
+{
+	ERRF_FatalErrInfo error;
+	Result ret;
+	size_t msglen;
+
+	if (R_FAILED(ret = errfInit()))
+		return ret;
+
+	memset(&error, 0, sizeof(error));
+
+	error.type = ERRF_ERRTYPE_FAILURE;
+	getCommonErrorData(&error, failure);
+
+	if ((msglen = strlen(message)) > sizeof(error.data.failure_mesg) - 1)
+		msglen = sizeof(error.data.failure_mesg) - 1;
+
+	memcpy(error.data.failure_mesg, message, msglen);
+	error.data.failure_mesg[msglen] = '\0';
+
+	ret = ERRF_Throw(&error);
+
+	errfExit();
+
+	return ret;
 }


### PR DESCRIPTION
I found out some more stuff via blind testing and updated 3dbrew accordingly.

This commit is cleanup of my previous code (and improves the documentation) as well as exposes values that weren't documented before on 3dbrew (which I have since signed up and added.) It also adds a few wrappers for easy use.

Error type 1 is identical to generic aside from a different message on the bottom screen that says the system memory is damaged, and error type 2 shows the screen that you get from removing a DS cart that is running (I assume it's the same, at least.)

It also appears the actual error screen isn't shown until the port is closed, which is rather strange, so the wrappers perform the intialization and close themselves.