### PR TITLE
Add httpcSetKeepAlive() to turn HTTP Keep-Alive on and off

### DIFF
--- a/libctru/include/3ds/services/httpc.h
+++ b/libctru/include/3ds/services/httpc.h
@@ -252,3 +252,10 @@ Result httpcCloseClientCertContext(u32 ClientCert_contexthandle);
  */
 Result httpcDownloadData(httpcContext *context, u8* buffer, u32 size, u32 *downloadedsize);
 
+/**
+ * @brief Sets Keep-Alive for the context.
+ * @param context Context to set flags on.
+ * @param options Keep-Alive option flags.
+ */
+Result httpcSetKeepAlive(httpcContext *context, u32 options);
+

--- a/libctru/include/3ds/services/httpc.h
+++ b/libctru/include/3ds/services/httpc.h
@@ -25,6 +25,12 @@ typedef enum {
 	HTTPC_STATUS_DOWNLOAD_READY = 0x7       ///< Download ready.
 } HTTPC_RequestStatus;
 
+/// HTTP KeepAlive option.
+typedef enum {
+	HTTPC_KEEPALIVE_DISABLED = 0x0,
+	HTTPC_KEEPALIVE_ENABLED = 0x1
+} HTTPC_KeepAlive;
+
 /// Result code returned when a download is pending.
 #define HTTPC_RESULTCODE_DOWNLOADPENDING 0xd840a02b
 
@@ -254,8 +260,8 @@ Result httpcDownloadData(httpcContext *context, u8* buffer, u32 size, u32 *downl
 
 /**
  * @brief Sets Keep-Alive for the context.
- * @param context Context to set flags on.
- * @param options Keep-Alive option flags.
+ * @param context Context to set the KeepAlive flag on.
+ * @param option HTTPC_KeepAlive option.
  */
-Result httpcSetKeepAlive(httpcContext *context, u32 options);
+Result httpcSetKeepAlive(httpcContext *context, HTTPC_KeepAlive option);
 

--- a/libctru/source/services/httpc.c
+++ b/libctru/source/services/httpc.c
@@ -650,13 +650,13 @@ Result httpcCloseClientCertContext(u32 ClientCert_contexthandle)
 	return cmdbuf[1];
 }
 
-Result httpcSetKeepAlive(httpcContext *context, u32 options)
+Result httpcSetKeepAlive(httpcContext *context, HTTPC_KeepAlive option)
 {
 	u32* cmdbuf=getThreadCommandBuffer();
 
 	cmdbuf[0]=IPC_MakeHeader(0x37,2,0); // 0x370080
 	cmdbuf[1]=context->httphandle;
-	cmdbuf[2]=options;
+	cmdbuf[2]=option;
 
 	Result ret=0;
 	if(R_FAILED(ret=svcSendSyncRequest(context->servhandle)))return ret;

--- a/libctru/source/services/httpc.c
+++ b/libctru/source/services/httpc.c
@@ -649,3 +649,17 @@ Result httpcCloseClientCertContext(u32 ClientCert_contexthandle)
 
 	return cmdbuf[1];
 }
+
+Result httpcSetKeepAlive(httpcContext *context, u32 options)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x37,2,0); // 0x370080
+	cmdbuf[1]=context->httphandle;
+	cmdbuf[2]=options;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(context->servhandle)))return ret;
+
+	return cmdbuf[1];
+}


### PR DESCRIPTION
Being able to enable/disable Connection: Keep-Alive for HTTP is kind of a big deal.