### PR TITLE
Implement some cfg functions.

### DIFF
--- a/libctru/include/3ds/services/cfgu.h
+++ b/libctru/include/3ds/services/cfgu.h
@@ -85,12 +85,50 @@ Result CFGU_GetCountryCodeString(u16 code, u16* string);
 Result CFGU_GetCountryCodeID(u16 string, u16* code);
 
 /**
- * @brief Gets a config info block.
+ * @brief Gets a config info block with flags = 2.
  * @param size Size of the data to retrieve.
  * @param blkID ID of the block to retrieve.
  * @param outData Pointer to write the block data to.
  */
 Result CFGU_GetConfigInfoBlk2(u32 size, u32 blkID, u8* outData);
+
+/**
+ * @brief Gets a config info block with flags = 4.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param outData Pointer to write the block data to.
+ */
+Result CFG_GetConfigInfoBlk4(u32 size, u32 blkID, u8* outData);
+
+/**
+ * @brief Gets a config info block with flags = 8.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param outData Pointer to write the block data to.
+ */
+Result CFG_GetConfigInfoBlk8(u32 size, u32 blkID, u8* outData);
+
+/**
+ * @brief Sets a config info block with flags = 4.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param inData Pointer to block data to write.
+ */
+Result CFG_SetConfigInfoBlk4(u32 size, u32 blkID, u8* inData);
+
+/**
+ * @brief Sets a config info block with flags = 8.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param inData Pointer to block data to write.
+ */
+Result CFG_SetConfigInfoBlk8(u32 size, u32 blkID, u8* inData);
+
+
+/**
+ * @brief Writes the CFG buffer in memory to the savegame in NAND.
+ */
+Result CFG_UpdateConfigNANDSavegame(void);
 
 /**
  * @brief Gets the system's language.

--- a/libctru/source/services/cfgu.c
+++ b/libctru/source/services/cfgu.c
@@ -151,6 +151,82 @@ Result CFGU_GetConfigInfoBlk2(u32 size, u32 blkID, u8* outData)
 	return (Result)cmdbuf[1];
 }
 
+Result CFG_GetConfigInfoBlk4(u32 size, u32 blkID, u8* outData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x401,2,2); // 0x4010082
+	cmdbuf[1] = size;
+	cmdbuf[2] = blkID;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_W);
+	cmdbuf[4] = (u32)outData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_GetConfigInfoBlk8(u32 size, u32 blkID, u8* outData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x801,2,2); // 0x8010082
+	cmdbuf[1] = size;
+	cmdbuf[2] = blkID;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_W);
+	cmdbuf[4] = (u32)outData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_SetConfigInfoBlk4(u32 size, u32 blkID, u8* inData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x402,2,2); // 0x4020082
+	cmdbuf[1] = blkID;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_R);
+	cmdbuf[4] = (u32)inData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_SetConfigInfoBlk8(u32 size, u32 blkID, u8* inData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x802,2,2); // 0x8020082
+	cmdbuf[1] = blkID;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_R);
+	cmdbuf[4] = (u32)inData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_UpdateConfigNANDSavegame(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x803,0,0); // 0x8030000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
 Result CFGU_GetSystemLanguage(u8* language)
 {
 	return CFGU_GetConfigInfoBlk2(1, 0xA0002, language);


### PR DESCRIPTION
Implements some functions in cfg:i to read/write to config savegame blocks, and to flush those blocks to the NAND savegame.

Previous pull request was closed on account of my committing an older version of the changes that had a missing semicolon.