### PR TITLE
Change svcKernelSetStateSignature

### DIFF
--- a/libctru/include/3ds/svc.h
+++ b/libctru/include/3ds/svc.h
@@ -907,12 +907,9 @@ Result svcGetSystemInfo(s64* out, u32 type, s32 param);
 
 /**
  * @brief Sets the current kernel state.
- * @param type Type of state to set.
- * @param param0 First parameter of the state.
- * @param param1 Second parameter of the state.
- * @param param2 Third parameter of the state.
+ * @param type Type of state to set (the other parameters depend on it).
  */
-Result svcKernelSetState(u32 type, u32 param0, u32 param1, u32 param2);
+Result svcKernelSetState(u32 type, ...);
 ///@}
 
 


### PR DESCRIPTION
`svcKernelSetState` behaves like a variadic function. This change, in addition of not breaking anything, would allow writing things like:

```c
svcKernelSetState(0, 0x0004013800000002ULL, 0); // firm-launch
svcKernelSetState(7); // MCU reboot
````

which is more explicit than what was used before