### PR TITLE
Fix ERRF_ExceptionData definition

### DIFF
--- a/libctru/include/3ds/errf.h
+++ b/libctru/include/3ds/errf.h
@@ -38,7 +38,6 @@ typedef struct {
 typedef struct {
 	ERRF_ExceptionInfo excep;   ///< Exception info struct
 	CpuRegisters regs;          ///< CPU register dump.
-	u8 pad[4];
 } ERRF_ExceptionData;
 
 typedef struct {


### PR DESCRIPTION
This "padding" field is not needed (the struct is used within an union when sent to ErrDisp), and is also undesirable as the kernel push an instance of `ERRF_ExceptionData` (which is a struct of size 0x5C, and not 0x60) on the user stack under certain conditions.