### PR TITLE
Add threadDetach function

### DIFF
--- a/libctru/include/3ds/thread.h
+++ b/libctru/include/3ds/thread.h
@@ -66,6 +66,12 @@ void threadFree(Thread thread);
 Result threadJoin(Thread thread, u64 timeout_ns);
 
 /**
+ *  @brief Changes a thread's status from attached to detached.
+ *  @param thread libctru thread handle
+ */
+void threadDetach(Thread thread);
+
+/**
  * @brief Retrieves the libctru thread handle of the current thread.
  * @return libctru thread handle of the current thread, or NULL for the main thread
  */

--- a/libctru/source/thread.c
+++ b/libctru/source/thread.c
@@ -107,6 +107,19 @@ Result threadJoin(Thread thread, u64 timeout_ns)
 	return svcWaitSynchronization(thread->handle, timeout_ns);
 }
 
+void threadDetach(Thread thread)
+{
+	if (!thread || thread->detached)
+		return;
+	if (thread->finished)
+	{
+		threadFree(thread);
+		return;
+	}
+	thread->detached = true;
+	return;
+}
+
 Thread threadGetCurrent(void)
 {
 	ThreadVars* tv = getThreadVars();


### PR DESCRIPTION
Most of the time it's sufficient to simply declare a thread as attached or unattached upon creation, but there do exist cases where it's useful to detach an already-running thread. I've come across such a case in my own code so here we are.