### PR TITLE
Fix ThreadContext definition and a typo in definition of struct FpuRegisters

### DIFF
--- a/libctru/include/3ds/types.h
+++ b/libctru/include/3ds/types.h
@@ -72,7 +72,7 @@ typedef struct {
 typedef struct {
 	union {
 		struct PACKED { double d[16]; }; ///< d0-d15.
-		float  f[32];                    ///< f0-f31.
+		float  s[32];                    ///< s0-s31.
 	};
 	u32 fpscr;        ///< fpscr.
 	u32 fpexc;        ///< fpexc.

--- a/libctru/include/3ds/types.h
+++ b/libctru/include/3ds/types.h
@@ -70,9 +70,9 @@ typedef struct {
 
 /// Structure representing FPU registers
 typedef struct {
-	union{
-		double d[16]; ///< d0-d15.
-		float  f[32]; ///< f0-f31.
+	union {
+		struct PACKED { double d[16]; }; ///< d0-d15.
+		float  f[32];                    ///< f0-f31.
 	};
 	u32 fpscr;        ///< fpscr.
 	u32 fpexc;        ///< fpexc.


### PR DESCRIPTION
Its correct size is 0xcc bytes, not the 8-byte aligned 0xd0