### PR TITLE
Add call frame information for SVC wrapper, fix build issue in uds.c

### DIFF
--- a/libctru/source/services/uds.c
+++ b/libctru/source/services/uds.c
@@ -501,13 +501,10 @@ Result udsScanBeacons(void *buf, size_t maxsize, udsNetworkScanInfo **networks, 
 		{
 			networks_ptr = malloc(sizeof(udsNetworkScanInfo) * hdr->total_entries);
 			if(networks_ptr == NULL)return -1;
+			if(total_networks)*total_networks = hdr->total_entries;
 			memset(networks_ptr, 0, sizeof(udsNetworkScanInfo) * hdr->total_entries);
 			*networks = networks_ptr;
-		}
-		if(total_networks)*total_networks = hdr->total_entries;
 
-		if(networks)
-		{
 			for(entpos=0; entpos<hdr->total_entries; entpos++)
 			{
 				if(curpos >= hdr->size)

--- a/libctru/source/svc.s
+++ b/libctru/source/svc.s
@@ -6,7 +6,12 @@
 	.global \name
 	.type \name, %function
 	.align 2
+	.cfi_startproc
 \name:
+.endm
+
+.macro SVC_END
+	.cfi_endproc
 .endm
 
 SVC_BEGIN svcControlMemory
@@ -18,6 +23,7 @@ SVC_BEGIN svcControlMemory
 	str  r1, [r2]
 	ldr  r4, [sp], #4
 	bx   lr
+SVC_END
 
 SVC_BEGIN svcQueryMemory
 	push {r0, r1, r4-r6}
@@ -32,18 +38,22 @@ SVC_BEGIN svcQueryMemory
 	add  sp, sp, #8
 	pop  {r4-r6}
 	bx   lr
+SVC_END
 
 SVC_BEGIN svcExitProcess
 	svc 0x03
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessAffinityMask
 	svc 0x04
 	bx lr
+SVC_END
 
 SVC_BEGIN svcSetProcessAffinityMask
 	svc 0x05
 	bx lr
+SVC_END
 
 SVC_BEGIN svcGetProcessIdealProcessor
 	str r0, [sp, #-0x4]!
@@ -51,10 +61,12 @@ SVC_BEGIN svcGetProcessIdealProcessor
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx lr
+SVC_END
 
 SVC_BEGIN svcSetProcessIdealProcessor
 	svc 0x07
 	bx lr
+SVC_END
 
 SVC_BEGIN svcCreateThread
 	push {r0, r4}
@@ -65,14 +77,17 @@ SVC_BEGIN svcCreateThread
 	str  r1, [r2]
 	ldr  r4, [sp], #4
 	bx   lr
+SVC_END
 
 SVC_BEGIN svcExitThread
 	svc 0x09
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSleepThread
 	svc 0x0A
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetThreadPriority
 	str r0, [sp, #-0x4]!
@@ -80,18 +95,22 @@ SVC_BEGIN svcGetThreadPriority
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSetThreadPriority
 	svc 0x0C
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetThreadAffinityMask
 	svc 0x0D
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSetThreadAffinityMask
 	svc 0x0E
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetThreadIdealProcessor
 	str r0, [sp, #-0x4]!
@@ -99,14 +118,17 @@ SVC_BEGIN svcGetThreadIdealProcessor
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSetThreadIdealProcessor
 	svc 0x10
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessorID
 	svc 0x11
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcRun
 	push {r4,r5}
@@ -118,6 +140,7 @@ SVC_BEGIN svcRun
 	svc 0x12
 	pop {r4,r5}
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateMutex
 	str r0, [sp, #-4]!
@@ -125,10 +148,12 @@ SVC_BEGIN svcCreateMutex
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcReleaseMutex
 	svc 0x14
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateSemaphore
 	push {r0}
@@ -136,6 +161,7 @@ SVC_BEGIN svcCreateSemaphore
 	pop {r3}
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcReleaseSemaphore
 	push {r0}
@@ -143,6 +169,7 @@ SVC_BEGIN svcReleaseSemaphore
 	pop  {r3}
 	str  r1, [r3]
 	bx   lr
+SVC_END
 
 SVC_BEGIN svcCreateEvent
 	str r0, [sp, #-4]!
@@ -150,14 +177,17 @@ SVC_BEGIN svcCreateEvent
 	ldr r2, [sp], #4
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSignalEvent
 	svc 0x18
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcClearEvent
 	svc 0x19
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateTimer
 	str r0, [sp, #-4]!
@@ -165,6 +195,7 @@ SVC_BEGIN svcCreateTimer
 	ldr r2, [sp], #4
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSetTimer
 	str r4, [sp, #-4]!
@@ -173,14 +204,17 @@ SVC_BEGIN svcSetTimer
 	svc 0x1B
 	ldr r4, [sp], #4
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCancelTimer
 	svc 0x1C
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcClearTimer
 	svc 0x1D
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateMemoryBlock
 	str r0, [sp, #-4]!
@@ -189,14 +223,17 @@ SVC_BEGIN svcCreateMemoryBlock
 	ldr r2, [sp], #4
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcMapMemoryBlock
 	svc 0x1F
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcUnmapMemoryBlock
 	svc 0x20
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateAddressArbiter
 	push {r0}
@@ -204,6 +241,7 @@ SVC_BEGIN svcCreateAddressArbiter
 	pop {r2}
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcArbitrateAddress
 	push {r4, r5}
@@ -212,14 +250,17 @@ SVC_BEGIN svcArbitrateAddress
 	svc 0x22
 	pop {r4, r5}
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCloseHandle
 	svc 0x23
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcWaitSynchronization
 	svc 0x24
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcWaitSynchronizationN
 	str r5, [sp, #-4]!
@@ -232,6 +273,7 @@ SVC_BEGIN svcWaitSynchronizationN
 	ldr r4, [sp], #4
 	ldr r5, [sp], #4
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcDuplicateHandle
 	str r0, [sp, #-0x4]!
@@ -239,10 +281,12 @@ SVC_BEGIN svcDuplicateHandle
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetSystemTick
 	svc 0x28
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetHandleInfo
 	str r0, [sp, #-0x4]!
@@ -251,6 +295,7 @@ SVC_BEGIN svcGetHandleInfo
 	str r1, [r3]
 	str r2, [r3,#4]
 	bx lr
+SVC_END
 
 SVC_BEGIN svcGetSystemInfo
 	str r0, [sp, #-0x4]!
@@ -259,6 +304,7 @@ SVC_BEGIN svcGetSystemInfo
 	str r1, [r3]
 	str r2, [r3,#4]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessInfo
 	str r0, [sp, #-0x4]!
@@ -267,6 +313,7 @@ SVC_BEGIN svcGetProcessInfo
 	str r1, [r3]
 	str r2, [r3,#4]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetThreadInfo
 	str r0, [sp, #-0x4]!
@@ -275,6 +322,7 @@ SVC_BEGIN svcGetThreadInfo
 	str r1, [r3]
 	str r2, [r3,#4]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcConnectToPort
 	str r0, [sp, #-0x4]!
@@ -282,10 +330,12 @@ SVC_BEGIN svcConnectToPort
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSendSyncRequest
 	svc 0x32
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcOpenProcess
 	push {r0}
@@ -293,6 +343,7 @@ SVC_BEGIN svcOpenProcess
 	pop {r2}
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcOpenThread
 	push {r0}
@@ -300,6 +351,7 @@ SVC_BEGIN svcOpenThread
 	pop {r2}
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessId
 	str r0, [sp, #-0x4]!
@@ -307,6 +359,7 @@ SVC_BEGIN svcGetProcessId
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessIdOfThread
 	str r0, [sp, #-0x4]!
@@ -314,6 +367,7 @@ SVC_BEGIN svcGetProcessIdOfThread
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetThreadId
 	str r0, [sp, #-0x4]!
@@ -321,6 +375,7 @@ SVC_BEGIN svcGetThreadId
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetResourceLimit
 	str r0, [sp, #-0x4]!
@@ -328,22 +383,27 @@ SVC_BEGIN svcGetResourceLimit
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetResourceLimitLimitValues
 	svc 0x39
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetResourceLimitCurrentValues
 	svc 0x3A
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcBreak
 	svc 0x3C
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcOutputDebugString
 	svc 0x3D
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreatePort
 	push {r0, r1}
@@ -354,6 +414,7 @@ SVC_BEGIN svcCreatePort
 	str r2, [r3]
 	add sp, sp, #8
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcAcceptSession
 	str r0, [sp, #-4]!
@@ -362,6 +423,7 @@ SVC_BEGIN svcAcceptSession
 	str r1, [r2]
 	add sp, sp, #4
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcReplyAndReceive
 	str r0, [sp, #-4]!
@@ -370,26 +432,32 @@ SVC_BEGIN svcReplyAndReceive
 	str r1, [r2]
 	add sp, sp, #4
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcBindInterrupt
 	svc 0x50
 	bx lr
+SVC_END
 
 SVC_BEGIN svcUnbindInterrupt
 	svc 0x51
 	bx lr
+SVC_END
 
 SVC_BEGIN svcInvalidateProcessDataCache
 	svc 0x52
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcStoreProcessDataCache
 	svc 0x53
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcFlushProcessDataCache
 	svc 0x54
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcStartInterProcessDma
 	stmfd sp!, {r0, r4, r5}
@@ -400,10 +468,12 @@ SVC_BEGIN svcStartInterProcessDma
 	ldmfd sp!, {r2, r4, r5}
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcStopDma
 	svc 0x56
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetDmaState
 	str r0, [sp, #-4]!
@@ -411,6 +481,7 @@ SVC_BEGIN svcGetDmaState
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcDebugActiveProcess
 	push {r0}
@@ -418,22 +489,27 @@ SVC_BEGIN svcDebugActiveProcess
 	pop {r2}
 	str r1, [r2]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcBreakDebugProcess
 	svc 0x61
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcTerminateDebugProcess
 	svc 0x62
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessDebugEvent
 	svc 0x63
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcContinueDebugEvent
 	svc 0x64
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetProcessList
 	str r0, [sp, #-0x4]!
@@ -441,6 +517,7 @@ SVC_BEGIN svcGetProcessList
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetThreadList
 	str r0, [sp, #-0x4]!
@@ -448,14 +525,17 @@ SVC_BEGIN svcGetThreadList
 	ldr r3, [sp], #4
 	str r1, [r3]
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetDebugThreadContext
 	svc 0x67
 	bx lr
+SVC_END
 
 SVC_BEGIN svcSetDebugThreadContext
 	svc 0x68
 	bx lr
+SVC_END
 
 SVC_BEGIN svcQueryDebugProcessMemory
 	push {r0, r1, r4-r6}
@@ -467,18 +547,22 @@ SVC_BEGIN svcQueryDebugProcessMemory
 	add sp, sp, #8
 	pop {r4-r6}
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcReadProcessMemory
 	svc 0x6A
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcWriteProcessMemory
 	svc 0x6B
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcSetHardwareBreakPoint
 	svc 0x6C
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcGetDebugThreadParam
 	push {r0, r1, r4, r5}
@@ -489,6 +573,7 @@ SVC_BEGIN svcGetDebugThreadParam
 	str r3, [r5]
 	pop {r4, r5}
 	bx lr
+SVC_END
 
 SVC_BEGIN svcControlProcessMemory
 	push {r4-r5}
@@ -497,14 +582,17 @@ SVC_BEGIN svcControlProcessMemory
 	svc 0x70
 	pop {r4-r5}
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcMapProcessMemory
 	svc 0x71
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcUnmapProcessMemory
 	svc 0x72
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateCodeSet
 	str r0, [sp, #-0x4]!
@@ -514,6 +602,7 @@ SVC_BEGIN svcCreateCodeSet
 	str r1, [r2]
 	add sp, sp, #4
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcCreateProcess
 	str r0, [sp, #-0x4]!
@@ -522,18 +611,22 @@ SVC_BEGIN svcCreateProcess
 	str r1, [r2]
 	add sp, sp, #4
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcTerminateProcess
 	svc 0x76
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcBackdoor
 	svc 0x7B
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcKernelSetState
 	svc 0x7C
 	bx  lr
+SVC_END
 
 SVC_BEGIN svcQueryProcessMemory
 	push {r0, r1, r4-r6}
@@ -545,3 +638,4 @@ SVC_BEGIN svcQueryProcessMemory
 	add sp, sp, #8
 	pop {r4-r6}
 	bx  lr
+SVC_END


### PR DESCRIPTION
This is needed for debugging (otherwise tools like GDB might crash or error out while doing frame analysis).

Additionally, it'd be best if the `Makefile` was edited to produce both "release" and "debug" builds (the debug builds would be built with `-Og` and _without_ `-fomit-frame-pointer`), but I don't know how to achieve that personally.

