### PR TITLE
added a necessary include

### DIFF
--- a/libctru/include/3ds/synchronization.h
+++ b/libctru/include/3ds/synchronization.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 #include <sys/lock.h>
+#include <3ds/svc.h>
 
 /// A light lock.
 typedef _LOCK_T LightLock;


### PR DESCRIPTION
Example for when this include is necessary
https://github.com/libretro/mgba

`/opt/devkitpro/devkitARM/bin/arm-none-eabi-gcc -c -o src/core/log.o src/core/log.c -march=armv6k -mtune=mpcore -mfloat-abi=hard -Wall -mword-relocations -fomit-frame-pointer -ffast-math -I/opt/devkitpro/libctru//include -DDISABLE_THREADING -O3    -DGIT_VERSION=\"" fdaaaee6"\" -std=c99 -DHAVE_STRNDUP -DHAVE_STRDUP -DARM11 -D_3DS -DUSE_VFS_3DS -D__LIBRETRO__ -DMINIMAL_CORE=2 -DM_CORE_GBA -DM_CORE_GB -DHAVE_STDINT_H -DHAVE_INTTYPES_H -DINLINE=inline -DCOLOR_16_BIT -DCOLOR_5_6_5 -DRESAMPLE_LIBRARY=2 -DM_PI=3.14159265358979323846 -DPATH_MAX=4096 -DSSIZE_MAX=32767 -DNDEBUG -DHAVE_LOCALTIME_R -I./src -I./src/arm

In file included from /opt/devkitpro/libctru//include/3ds/thread.h:8:0,
                 from ./src/util/threading.h:27,
                 from ./src/core/sync.h:11,
                 from ./src/core/thread.h:13,
                 from src/core/log.c:8:
/opt/devkitpro/libctru//include/3ds/synchronization.h:130:41: error: unknown type name 'ResetType'
 void LightEvent_Init(LightEvent* event, ResetType reset_type);
                                         ^~~~~~~~~
make: *** [Makefile.libretro:289: src/core/log.o] Error 1`