### PR TITLE
nfcStartOtherTagScanning(): Call StartCommunication() for Old3DS compatibility.

### DIFF
--- a/libctru/source/services/nfc.c
+++ b/libctru/source/services/nfc.c
@@ -37,7 +37,13 @@ Result nfcInit(NFC_OpType type)
 	if (R_SUCCEEDED(ret))
 	{
 		nfc_optype = type;
-		ret = NFC_Initialize(type);
+		for (;;)
+		{
+			ret = NFC_Initialize(type);
+			if (ret != 0xd0a17480)
+				break;
+			svcSleepThread(500000);
+		}
 		if (R_FAILED(ret)) svcCloseHandle(nfcHandle);
 	}
 	if (R_FAILED(ret)) AtomicDecrement(&nfcRefCount);


### PR DESCRIPTION
Duplicated Old 3DS compatibility code from nfcStartTagScanning() for nfcStartOtherTagScanning(). Could refactor more if needed.