### PR TITLE
Added and adjusted clock speed constants

### DIFF
--- a/libctru/include/3ds/ndsp/ndsp.h
+++ b/libctru/include/3ds/ndsp/ndsp.h
@@ -4,6 +4,10 @@
  */
 #pragma once
 
+#include <3ds/os.h>
+
+#define NDSP_SAMPLE_RATE (SYSCLOCK_SOC / 512.0)
+
 ///@name Data types
 ///@{
 /// Sound output modes.

--- a/libctru/include/3ds/os.h
+++ b/libctru/include/3ds/os.h
@@ -5,6 +5,14 @@
 #pragma once
 #include "svc.h"
 
+#define SYSCLOCK_SOC       (16756991)
+#define SYSCLOCK_ARM9      (SYSCLOCK_SOC * 8)
+#define SYSCLOCK_ARM11     (SYSCLOCK_ARM9 * 2)
+#define SYSCLOCK_ARM11_NEW (SYSCLOCK_ARM11 * 3)
+
+#define CPU_TICKS_PER_MSEC (SYSCLOCK_ARM11 / 1000.0)
+#define CPU_TICKS_PER_USEC (SYSCLOCK_ARM11 / 1000000.0)
+
 /// Packs a system version from its components.
 #define SYSTEM_VERSION(major, minor, revision) \
 	(((major)<<24)|((minor)<<16)|((revision)<<8))

--- a/libctru/include/3ds/services/mic.h
+++ b/libctru/include/3ds/services/mic.h
@@ -16,10 +16,10 @@ typedef enum
 /// Microphone audio sampling rates.
 typedef enum
 {
-	MICU_SAMPLE_RATE_32730 = 0, ///< 32730 Hz
-	MICU_SAMPLE_RATE_16360 = 1, ///< 16360 Hz
-	MICU_SAMPLE_RATE_10910 = 2, ///< 10910 Hz
-	MICU_SAMPLE_RATE_8180 =  3, ///< 8180 Hz
+	MICU_SAMPLE_RATE_32730 = 0, ///< 32728.498 Hz
+	MICU_SAMPLE_RATE_16360 = 1, ///< 16364.479 Hz
+	MICU_SAMPLE_RATE_10910 = 2, ///< 10909.499 Hz
+	MICU_SAMPLE_RATE_8180 =  3, ///< 8182.1245 Hz
 } MICU_SampleRate;
 
 /**

--- a/libctru/source/ndsp/ndsp-channel.c
+++ b/libctru/source/ndsp/ndsp-channel.c
@@ -123,7 +123,7 @@ void ndspChnSetRate(int id, float rate)
 {
 	ndspChnSt* chn = &ndspChn[id];
 	LightLock_Lock(&chn->lock);
-	chn->rate = rate/32728.0f;
+	chn->rate = rate / NDSP_SAMPLE_RATE;
 	chn->flags |= CFLAG_RATE;
 	LightLock_Unlock(&chn->lock);
 }

--- a/libctru/source/ndsp/ndsp-filter.c
+++ b/libctru/source/ndsp/ndsp-filter.c
@@ -3,7 +3,7 @@
 #include <3ds/ndsp/ndsp.h>
 #include <3ds/ndsp/channel.h>
 
-#define Fs 32728.0f
+#define Fs NDSP_SAMPLE_RATE
 
 bool ndspChnIirMonoSetParamsLowPassFilter(int id, float f0)
 {

--- a/libctru/source/os.c
+++ b/libctru/source/os.c
@@ -8,9 +8,6 @@
 #include <reent.h>
 #include <unistd.h>
 
-#define TICKS_PER_USEC 268.111856
-#define TICKS_PER_MSEC 268111.856
-
 // Work around the VFP not supporting 64-bit integer <--> floating point conversion
 static inline double u64_to_double(u64 value) {
 	return (((double)(u32)(value >> 32))*0x100000000ULL+(u32)value);
@@ -85,7 +82,7 @@ int __libctru_gtod(struct _reent *ptr, struct timeval *tp, struct timezone *tz) 
 
 		u64 delta = svcGetSystemTick() - dt.update_tick;
 
-		u32 offset =  (u32)(u64_to_double(delta)/TICKS_PER_USEC);
+		u32 offset =  (u32)(u64_to_double(delta)/CPU_TICKS_PER_USEC);
 
 		// adjust from 1900 to 1970
 		u64 now = ((dt.date_time - 2208988800000ULL) * 1000) + offset;
@@ -112,13 +109,13 @@ u64 osGetTime(void) {
 
 	u64 delta = svcGetSystemTick() - dt.update_tick;
 
-	return dt.date_time + (u32)(u64_to_double(delta)/TICKS_PER_MSEC);
+	return dt.date_time + (u32)(u64_to_double(delta)/CPU_TICKS_PER_MSEC);
 }
 
 //---------------------------------------------------------------------------------
 double osTickCounterRead(TickCounter* cnt) {
 //---------------------------------------------------------------------------------
-	return u64_to_double(cnt->elapsed) / TICKS_PER_MSEC;
+	return u64_to_double(cnt->elapsed) / CPU_TICKS_PER_MSEC;
 }
 
 //---------------------------------------------------------------------------------


### PR DESCRIPTION
Since some values were off by (literally) a fraction, I added defines to accurately calculate some of the clock speeds in the system.

Since these constants were moved to os.h, others could also potentially use it in their timing-critical applications (like hardware-based sound sequencing), including the DSP playback sampling rate for more accurate pitch shifting.