### PR TITLE
Fix missing include <3ds/types.h>

### DIFF
--- a/libctru/include/3ds/applets/error.h
+++ b/libctru/include/3ds/applets/error.h
@@ -3,6 +3,8 @@
  * @brief Error applet.
  */
 #pragma once
+#include <3ds/types.h>
+
  enum
 {
 	ERROR_LANGUAGE_FLAG = 0x100,    ///<??-Unknown flag

--- a/libctru/include/3ds/applets/miiselector.h
+++ b/libctru/include/3ds/applets/miiselector.h
@@ -4,6 +4,7 @@
  */
 
 #pragma once
+#include <3ds/types.h>
 
 /// Magic value needed to launch the applet.
 #define MIISELECTOR_MAGIC 0x13DE28CF

--- a/libctru/include/3ds/applets/swkbd.h
+++ b/libctru/include/3ds/applets/swkbd.h
@@ -3,6 +3,7 @@
  * @brief Software keyboard applet.
  */
 #pragma once
+#include <3ds/types.h>
 
 /// Keyboard types.
 typedef enum


### PR DESCRIPTION
This prevents compile errors from including these files directly without include <3ds/types.h> first.