### PR TITLE
Add undocumented N3DS PM launch flags

### DIFF
--- a/libctru/include/3ds/services/pm.h
+++ b/libctru/include/3ds/services/pm.h
@@ -11,6 +11,8 @@ enum {
 	PMLAUNCHFLAG_NOTIFY_TERMINATION            = BIT(2),
 	PMLAUNCHFLAG_QUEUE_DEBUG_APPLICATION       = BIT(3),
 	PMLAUNCHFLAG_TERMINATION_NOTIFICATION_MASK = 0xF0,
+	PMLAUNCHFLAG_FORCE_USE_O3DS_APP_MEM        = BIT(8),  ///< Forces the usage of the O3DS system mode app memory setting even if N3DS system mode is not "Legacy". Dev4 and Dev5 not supported. N3DS only.
+	PMLAUNCHFLAG_FORCE_USE_O3DS_MAX_APP_MEM    = BIT(9),  ///< In conjunction with the above, forces the 96MB app memory setting. N3DS only.
 	PMLAUNCHFLAG_USE_UPDATE_TITLE              = BIT(16),
 };
 


### PR DESCRIPTION
Relevant pm code (code from reimpl):
```cpp
    // Change APPMEMALLOC if needed
    if (IS_N3DS && APPMEMTYPE == 6 && (launchFlags & PMLAUNCHFLAG_NORMAL_APPLICATION) != 0) {
        u32 limitMb;
        SystemMode n3dsSystemMode = exheaderInfo->aci.local_caps.core_info.n3ds_system_mode;
        if ((launchFlags & PMLAUNCHFLAG_FORCE_USE_O3DS_APP_MEM) || n3dsSystemMode == SYSMODE_O3DS_PROD) {
            if ((launchFlags & PMLAUNCHFLAG_FORCE_USE_O3DS_APP_MEM) & PMLAUNCHFLAG_FORCE_USE_O3DS_MAX_APP_MEM) {
                limitMb = 96;
            } else {
                switch (exheaderInfo->aci.local_caps.core_info.o3ds_system_mode) {
                    case SYSMODE_O3DS_PROD: limitMb = 64; break;
                    case SYSMODE_DEV1:      limitMb = 96; break;
                    case SYSMODE_DEV2:      limitMb = 80; break;
                    default:                limitMb = 0;  break;
                }
            }

            setAppMemLimit(limitMb << 20);
        }
    }
```