### PR TITLE
Add apt function to allow disabling home button

### DIFF
--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -159,6 +159,18 @@ bool aptIsSleepAllowed(void);
 void aptSetSleepAllowed(bool allowed);
 
 /**
+ * @brief Gets whether to allow the system to go back to HOME menu.
+ * @return Whether going back to HOME menu is allowed.
+ */
+bool aptIsHomeAllowed(void);
+
+/**
+ * @brief Sets whether to allow the system to go back to HOME menu.
+ * @param allowed Whether going back to HOME menu is allowed.
+ */
+void aptSetHomeAllowed(bool allowed);
+
+/**
  * @brief Processes the current APT status. Generally used within a main loop.
  * @return Whether the application should continue running.
  */

--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -171,6 +171,12 @@ bool aptIsHomeAllowed(void);
 void aptSetHomeAllowed(bool allowed);
 
 /**
+ * @brief Returns when the HOME button is pressed.
+ * @return Whether the HOME button is being pressed.
+ */
+bool aptIsHomePressed(void);
+
+/**
  * @brief Processes the current APT status. Generally used within a main loop.
  * @return Whether the application should continue running.
  */

--- a/libctru/source/services/apt.c
+++ b/libctru/source/services/apt.c
@@ -41,6 +41,7 @@ enum
 
 static u8 aptHomeButtonState;
 static u32 aptFlags = FLAG_ALLOWSLEEP;
+static bool home_allowed = false;
 static u32 aptParameters[0x1000/4];
 static u64 aptChainloadTid;
 static u8 aptChainloadMediatype;
@@ -267,6 +268,16 @@ void aptSetSleepAllowed(bool allowed)
 	}
 }
 
+bool aptIsHomeAllowed(void)
+{
+	return home_allowed;
+}
+
+void aptSetHomeAllowed(bool allowed)
+{
+	home_allowed = allowed;
+}
+
 void aptSetChainloader(u64 programID, u8 mediatype)
 {
 	aptChainloadTid = programID;
@@ -338,10 +349,10 @@ void aptEventHandler(void *arg)
 		switch (signal)
 		{
 			case APTSIGNAL_HOMEBUTTON:
-				if (!aptHomeButtonState) aptHomeButtonState = 1;
+				if (!aptHomeButtonState && aptIsHomeAllowed()) aptHomeButtonState = 1;
 				break;
 			case APTSIGNAL_HOMEBUTTON2:
-				if (!aptHomeButtonState) aptHomeButtonState = 2;
+				if (!aptHomeButtonState && aptIsHomeAllowed()) aptHomeButtonState = 2;
 				break;
 			case APTSIGNAL_SLEEP_QUERY:
 				APT_ReplySleepQuery(envGetAptAppId(), aptIsSleepAllowed() ? APTREPLY_ACCEPT : APTREPLY_REJECT);

--- a/libctru/source/services/apt.c
+++ b/libctru/source/services/apt.c
@@ -41,7 +41,7 @@ enum
 
 static u8 aptHomeButtonState;
 static u32 aptFlags = FLAG_ALLOWSLEEP;
-static bool home_allowed = false;
+static bool aptHomeAllowed = false;
 static u32 aptParameters[0x1000/4];
 static u64 aptChainloadTid;
 static u8 aptChainloadMediatype;
@@ -270,12 +270,12 @@ void aptSetSleepAllowed(bool allowed)
 
 bool aptIsHomeAllowed(void)
 {
-	return home_allowed;
+	return aptHomeAllowed;
 }
 
 void aptSetHomeAllowed(bool allowed)
 {
-	home_allowed = allowed;
+	aptHomeAllowed = allowed;
 }
 
 void aptSetChainloader(u64 programID, u8 mediatype)


### PR DESCRIPTION
This pr replaces https://github.com/smealum/ctrulib/pull/406 as was discussed with asty and fincs.
Text below taken directly from said pr:

Add a function to allow enabling/disabling whether the home button is usable.

This allows homebrew to block the home button, similar to the eShop when loading, MH4U when online, and almost certainly other games/applications which I can't think of off the top of my head.

Kind of a hack and we're almost certainly forgetting something, but it seems to work fine.