### PR TITLE
services/{fs, mvd}: Remove redundant conditionals

### DIFF
--- a/libctru/source/services/fs.c
+++ b/libctru/source/services/fs.c
@@ -394,7 +394,7 @@ Result FSUSER_OpenArchive(FS_Archive* archive, FS_ArchiveID id, FS_Path path)
 	Result ret = 0;
 	if(R_FAILED(ret = svcSendSyncRequest(fsSession()))) return ret;
 
-	if(archive) *archive = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	*archive = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
 	return cmdbuf[1];
 }

--- a/libctru/source/services/mvd.c
+++ b/libctru/source/services/mvd.c
@@ -372,11 +372,8 @@ Result mvdstdRenderVideoFrame(MVDSTD_Config* config, bool wait)
 	if(config==NULL)return -1;
 	if(mvdstd_mode!=MVDMODE_VIDEOPROCESSING)return -2;
 
-	if(config)
-	{
-		ret = MVDSTD_SetConfig(config);
-		if(ret!=MVD_STATUS_OK)return ret;
-	}
+	ret = MVDSTD_SetConfig(config);
+	if(ret!=MVD_STATUS_OK)return ret;
 
 	ret = MVD_STATUS_BUSY;
 	while(ret==MVD_STATUS_BUSY)


### PR DESCRIPTION
Both `FSUSER_OpenArchive` and `mvdstdRenderVideoFrame` already check against these conditions, so we don't need to check against them again. This tidies the functions up a little