### PR TITLE
Add invalid glyph index protection

### DIFF
--- a/libctru/source/font.c
+++ b/libctru/source/font.c
@@ -48,7 +48,7 @@ int fontGlyphIndexFromCodePoint(CFNT_s* font, u32 codePoint)
 		font = g_sharedFont;
 	if (!font)
 		return -1;
-	int ret = font->finf.alterCharIndex;
+	int ret = 0xFFFF;
 	if (codePoint < 0x10000)
 	{
 		for (CMAP_s* cmap = font->finf.cmap; cmap; cmap = cmap->next)
@@ -78,6 +78,13 @@ int fontGlyphIndexFromCodePoint(CFNT_s* font, u32 codePoint)
 				break;
 			}
 		}
+	}
+	if (ret == 0xFFFF) // Bogus CMAP entry. Probably exist to save space by using TABLE mappings?
+	{
+		if (font->finf.alterCharIndex == 0xFFFF)
+			return -1;
+		else
+			return font->finf.alterCharIndex;
 	}
 	return ret;
 }


### PR DESCRIPTION
@mtheall recently found that some glyph indices returned are 0xFFFF, which are entirely outside of font boundaries. This adds protection to ensure that the only non-character index value returned is -1.