### PR TITLE
Add FSPXI interfaces

### DIFF
--- a/libctru/include/3ds.h
+++ b/libctru/include/3ds.h
@@ -40,6 +40,7 @@ extern "C" {
 #include <3ds/services/csnd.h>
 #include <3ds/services/dsp.h>
 #include <3ds/services/fs.h>
+#include <3ds/services/fspxi.h>
 #include <3ds/services/fsreg.h>
 #include <3ds/services/frd.h>
 #include <3ds/services/gspgpu.h>

--- a/libctru/include/3ds/services/fs.h
+++ b/libctru/include/3ds/services/fs.h
@@ -135,6 +135,7 @@ typedef enum
 {
 	ARCHIVE_ACTION_COMMIT_SAVE_DATA = 0, ///< Commits save data changes. No inputs/outputs.
 	ARCHIVE_ACTION_GET_TIMESTAMP    = 1, ///< Retrieves a file's last-modified timestamp. In: "u16*, UTF-16 Path", Out: "u64, Time Stamp".
+	ARCHIVE_ACTION_UNKNOWN			= 0x789D, //< Unknown action; calls FSPXI command 0x56. In: "FS_Path instance", Out: "u32[4], Unknown"
 } FS_ArchiveAction;
 
 /// Secure save control actions.
@@ -444,7 +445,7 @@ Result FSUSER_IsSdmcDetected(bool *detected);
 
 /**
  * @brief Gets whether the SD card is writable.
- * @param detected Pointer to output the writable status to.
+ * @param writable Pointer to output the writable status to.
  */
 Result FSUSER_IsSdmcWritable(bool *writable);
 
@@ -610,7 +611,7 @@ Result FSUSER_SetCardSpiBaudRate(FS_CardSpiBaudRate baudRate);
 
 /**
  * @brief Sets the CARDSPI bus mode.
- * @param baudRate Bus mode to set.
+ * @param busMode Bus mode to set.
  */
 Result FSUSER_SetCardSpiBusMode(FS_CardSpiBusMode busMode);
 
@@ -871,7 +872,7 @@ Result FSUSER_SetCtrCardLatencyParameter(u64 latency, bool emulateEndurance);
 
 /**
  * @brief Toggles cleaning up invalid save data.
- * @param Whether to enable cleaning up invalid save data.
+ * @param enable Whether to enable cleaning up invalid save data.
  */
 Result FSUSER_SwitchCleanupInvalidSaveData(bool enable);
 

--- a/libctru/include/3ds/services/fs.h
+++ b/libctru/include/3ds/services/fs.h
@@ -135,7 +135,7 @@ typedef enum
 {
 	ARCHIVE_ACTION_COMMIT_SAVE_DATA = 0, ///< Commits save data changes. No inputs/outputs.
 	ARCHIVE_ACTION_GET_TIMESTAMP    = 1, ///< Retrieves a file's last-modified timestamp. In: "u16*, UTF-16 Path", Out: "u64, Time Stamp".
-	ARCHIVE_ACTION_UNKNOWN			= 0x789D, //< Unknown action; calls FSPXI command 0x56. In: "FS_Path instance", Out: "u32[4], Unknown"
+	ARCHIVE_ACTION_UNKNOWN          = 0x789D, //< Unknown action; calls FSPXI command 0x56. In: "FS_Path instance", Out: "u32[4], Unknown"
 } FS_ArchiveAction;
 
 /// Secure save control actions.
@@ -538,7 +538,7 @@ Result FSUSER_CardNorDirectCommandWithAddress(u8 commandId, u32 address);
  * @param size Size of the output buffer.
  * @param output Output buffer.
  */
-Result FSUSER_CardNorDirectRead(u8 commandId, u32 size, u8* output);
+Result FSUSER_CardNorDirectRead(u8 commandId, u32 size, void* output);
 
 /**
  * @brief Executes a CARDNOR direct read with an address.
@@ -547,7 +547,7 @@ Result FSUSER_CardNorDirectRead(u8 commandId, u32 size, u8* output);
  * @param size Size of the output buffer.
  * @param output Output buffer.
  */
-Result FSUSER_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output);
+Result FSUSER_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, void* output);
 
 /**
  * @brief Executes a CARDNOR direct write.
@@ -555,7 +555,7 @@ Result FSUSER_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, 
  * @param size Size of the input buffer.
  * @param output Input buffer.
  */
-Result FSUSER_CardNorDirectWrite(u8 commandId, u32 size, u8* input);
+Result FSUSER_CardNorDirectWrite(u8 commandId, u32 size, const void* input);
 
 /**
  * @brief Executes a CARDNOR direct write with an address.
@@ -564,7 +564,7 @@ Result FSUSER_CardNorDirectWrite(u8 commandId, u32 size, u8* input);
  * @param size Size of the input buffer.
  * @param input Input buffer.
  */
-Result FSUSER_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input);
+Result FSUSER_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, const void* input);
 
 /**
  * @brief Executes a CARDNOR 4xIO direct read.
@@ -573,7 +573,7 @@ Result FSUSER_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size,
  * @param size Size of the output buffer.
  * @param output Output buffer.
  */
-Result FSUSER_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output);
+Result FSUSER_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, void* output);
 
 /**
  * @brief Executes a CARDNOR direct CPU write without verify.
@@ -581,7 +581,7 @@ Result FSUSER_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* ou
  * @param size Size of the input buffer.
  * @param output Input buffer.
  */
-Result FSUSER_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input);
+Result FSUSER_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, const void* input);
 
 /**
  * @brief Executes a CARDNOR direct sector erase without verify.
@@ -633,7 +633,7 @@ Result FSUSER_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 pro
  * @param programId ID of the program.
  * @param header Pointer to output the legacy ROM header to. (size = 0x3B4)
  */
-Result FSUSER_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header);
+Result FSUSER_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, void* header);
 
 /**
  * @brief Gets the legacy banner data of a program.
@@ -641,7 +641,7 @@ Result FSUSER_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* head
  * @param programId ID of the program.
  * @param header Pointer to output the legacy banner data to. (size = 0x23C0)
  */
-Result FSUSER_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner);
+Result FSUSER_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, void* banner);
 
 /**
  * @brief Checks a process's authority to access a save data archive.
@@ -698,7 +698,7 @@ Result FSUSER_GetFormatInfo(u32* totalSize, u32* directories, u32* files, bool* 
  * @param programId ID of the program.
  * @param header Pointer to output the legacy ROM header to.
  */
-Result FSUSER_GetLegacyRomHeader2(u32 headerSize, FS_MediaType mediaType, u64 programId, u8* header);
+Result FSUSER_GetLegacyRomHeader2(u32 headerSize, FS_MediaType mediaType, u64 programId, void* header);
 
 /**
  * @brief Gets the CTR SDMC root path.
@@ -746,7 +746,7 @@ Result FSUSER_FormatSaveData(FS_ArchiveID archiveId, FS_Path path, u32 blocks, u
  * @param programId ID of the program.
  * @param header Pointer to output the legacy sub banner data to.
  */
-Result FSUSER_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner);
+Result FSUSER_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, void* banner);
 
 /**
  * @brief Hashes the given data and outputs a SHA256 hash.
@@ -763,7 +763,7 @@ Result FSUSER_UpdateSha256Context(const void* data, u32 inputSize, u8* hash);
  * @param size Size of the buffer.
  * @param data Buffer to read to.
  */
-Result FSUSER_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data);
+Result FSUSER_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, void* data);
 
 /**
  * @brief Gets the size of a special file.

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -161,14 +161,20 @@ Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directory);
 Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path);
 
 /**
- * @brief Unknown 0x13
+ * @brief Checks if the archive contains a file at path.
+ * @param archive Archive to check.
+ * @param out Pointer to output existence to.
+ * @param path Path to check for file
  */
-Result FSPXI_Unknown0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, FS_Path path);
+Result FSPXI_HasFile(Handle serviceHandle, FSPXI_Archive archive, bool* out, FS_Path path);
 
 /**
- * @brief Unknown 0x14
+ * @brief Checks if the archive contains a directory at path.
+ * @param archive Archive to check.
+ * @param out Pointer to output existence to.
+ * @param path Path to check for directory
  */
-Result FSPXI_Unknown0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, FS_Path path);
+Result FSPXI_HasDirectory(Handle serviceHandle, FSPXI_Archive archive, bool* out, FS_Path path);
 
 /**
  * @brief Commits an archive's save data.
@@ -443,10 +449,10 @@ Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u6
 Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* banner, u8 unk);
 
 /**
- * Unknown command 3D
+ * @brief Formats the CARDNOR device.
  * @param unk Unknown. Transaction?
  */
-Result FSPXI_Unknown0x3D(Handle serviceHandle, u32 unk);
+Result FSPXI_FormatCardNorDevice(Handle serviceHandle, u32 unk);
 
 /// Deletes the 3DS SDMC root.
 Result FSPXI_DeleteSdmcRoot(Handle serviceHandle);
@@ -495,8 +501,12 @@ Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_Inte
  */
 Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, void* banner);
 
-/// Unknown command 47
-Result FSPXI_Unknown0x47(Handle serviceHandle, void* buf, u32 size);
+/**
+ * @brief Generates random bytes. Uses same code as PSPXI_GenerateRandomBytes
+ * @param buf Buffer to output random bytes to.
+ * @param size Size of buffer.
+ */
+Result FSPXI_GenerateRandomBytes(Handle serviceHandle, void* buffer, u32 size);
 
 /**
  * @brief Gets the last modified time of a file in an archive.
@@ -562,8 +572,11 @@ Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRea
  */
 Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2);
 
-/// Unknown command 4F
-Result FSPXI_Unknown0x4F(Handle serviceHandle, u64 unk);
+/**
+ * @brief Configures CTRCARD latency emulation.
+ * @param latency Latency to apply.
+ */
+Result FSPXI_SetCtrCardLatencyParameter(Handle serviceHandle, u64 latency);
 
 /**
  * @brief Sets the file system priority.

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -94,7 +94,7 @@ Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64
  * @param buffer Buffer to output the hash to.
  * @param size Size of the buffer.
  */
-Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, u32* buffer, u32 size);
+Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, void* buffer, u32 size);
 
 /**
  * @brief Writes to a file.

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -611,6 +611,3 @@ Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 un
  * @remark Called by FSUSER_ControlArchive with ArchiveAction 0x789D
  */
 Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[4], FS_Archive archive, FS_Path path);
-
-#undef DEFINE_PXIFS_SERVICE_METHOD
-#undef DEFINE_SERVICE_METHOD

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -1,0 +1,645 @@
+/**
+ * @file fspxi.h
+ * @brief Service interface for PxiFS services. This is normally not accessible to userland apps. https://3dbrew.org/wiki/Filesystem_services_PXI
+ */
+#pragma once
+
+#include <3ds/services/fs.h>
+#include <3ds/types.h>
+
+typedef u64 FSPXI_Archive;
+typedef u64 FSPXI_File;
+typedef u64 FSPXI_Directory;
+
+#define DEFINE_SERVICE_METHOD(servname, funcname, ...) Result servname ## _ ## funcname(__VA_ARGS__)
+#define DEFINE_PXIFS_SERVICE_METHOD(funcname, ...) DEFINE_SERVICE_METHOD(PXIFS0, funcname, __VA_ARGS__); \
+                                                   DEFINE_SERVICE_METHOD(PXIFS1, funcname, __VA_ARGS__); \
+                                                   DEFINE_SERVICE_METHOD(PXIFSR, funcname, __VA_ARGS__); \
+                                                   DEFINE_SERVICE_METHOD(PXIFSB, funcname, __VA_ARGS__)
+
+/**
+ * @brief Initializes PxiFS0.
+ * @param servhandle Optional service session handle to use for PxiFS0, if zero srvGetServiceHandle() will be used.
+ */
+Result pxifs0Init(Handle servhandle);
+
+/// Exits PxiFS0.
+void pxifs0Exit(void);
+
+/**
+ * @brief Initializes PxiFS1.
+ * @param servhandle Optional service session handle to use for PxiFS1, if zero srvGetServiceHandle() will be used.
+ */
+Result pxifs1Init(Handle servhandle);
+
+/// Exits PxiFS1.
+void pxifs1Exit(void);
+
+/**
+ * @brief Initializes PxiFSR.
+ * @param servhandle Optional service session handle to use for PxiFSR, if zero srvGetServiceHandle() will be used.
+ */
+Result pxifsRInit(Handle servhandle);
+
+/// Exits PxiFSR.
+void pxifsRExit(void);
+
+/**
+ * @brief Initializes PxiFSB.
+ * @param servhandle Optional service session handle to use for PxiFSB, if zero srvGetServiceHandle() will be used.
+ */
+Result pxifsBInit(Handle servhandle);
+
+/// Exits PxiFSB.
+void pxifsBExit(void);
+
+/**
+ * @brief Opens a file.
+ * @param out Pointer to output the file handle to.
+ * @param archive Archive containing the file.
+ * @param path Path of the file.
+ * @param flags Flags to open the file with.
+ * @param attributes Attributes of the file.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(OpenFile, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes);
+
+/**
+ * @brief Deletes a file.
+ * @param archive Archive containing the file.
+ * @param path Path of the file.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(DeleteFile, FSPXI_Archive archive, FS_Path path);
+
+/**
+ * @brief Renames a file.
+ * @param srcArchive Archive containing the source file.
+ * @param srcPath Path of the source file.
+ * @param dstArchive Archive containing the destination file.
+ * @param dstPath Path of the destination file.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(RenameFile, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath);
+
+/**
+ * @brief Deletes a directory.
+ * @param archive Archive containing the directory.
+ * @param path Path of the directory.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(DeleteDirectory, FSPXI_Archive archive, FS_Path path);
+
+/**
+ * @brief Creates a file.
+ * @param archive Archive to create the file in.
+ * @param path Path of the file.
+ * @param attributes Attributes of the file.
+ * @param size Size of the file.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CreateFile, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize);
+
+/**
+ * @brief Creates a directory.
+ * @param archive Archive to create the directory in.
+ * @param path Path of the directory.
+ * @param attributes Attributes of the directory.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CreateDirectory, FSPXI_Archive archive, FS_Path path, u32 attributes);
+
+/**
+ * @brief Renames a directory.
+ * @param srcArchive Archive containing the source directory.
+ * @param srcPath Path of the source directory.
+ * @param dstArchive Archive containing the destination directory.
+ * @param dstPath Path of the destination directory.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(RenameDirectory, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath);
+
+/**
+ * @brief Opens a directory.
+ * @param out Pointer to output the directory handle to.
+ * @param archive Archive containing the directory.
+ * @param path Path of the directory.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(OpenDirectory, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path);
+
+/**
+ * @brief Reads from a file.
+ * @param file File to read from.
+ * @param bytesRead Pointer to output the number of read bytes to.
+ * @param offset Offset to read from.
+ * @param buffer Buffer to read to.
+ * @param size Size of the buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ReadFile, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size);
+
+/**
+ * @brief Calculate SHA256 of a file.
+ * @param file File to calculate the hash of.
+ * @param buffer Buffer to output the hash to.
+ * @param size Size of the buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CalculateFileHashSHA256, FSPXI_File file, u32* buffer, u32 size);
+
+/**
+ * @brief Writes to a file.
+ * @param file File to write to.
+ * @param bytesWritten Pointer to output the number of bytes written to.
+ * @param offset Offset to write to.
+ * @param buffer Buffer to write from.
+ * @param size Size of the buffer.
+ * @param flags Flags to use when writing.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(WriteFile, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags);
+
+/**
+ * @brief Calculates the MAC used in a DISA/DIFF header?
+ * @param file Unsure
+ * @param inBuffer 0x100-byte DISA/DIFF input buffer.
+ * @param inSize Size of inBuffer.
+ * @param outBuffer Buffer to write MAC to.
+ * @param outSize Size of outBuffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CalcSavegameMAC, FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize);
+
+/**
+ * @brief Get size of a file
+ * @param file File to get the size of.
+ * @param size Pointer to output size to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetFileSize, FSPXI_File file, u64* size);
+
+/**
+ * @brief Set size of a file
+ * @param file File to set the size of
+ * @param size Size to set the file to
+ */
+DEFINE_PXIFS_SERVICE_METHOD(SetFileSize, FSPXI_File file, u64 size);
+
+/**
+ * @brief Close a file
+ * @param file File to close
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CloseFile, FSPXI_File file);
+
+/**
+ * @brief Reads one or more directory entries.
+ * @param directory Directory to read from.
+ * @param entriesRead Pointer to output the number of entries read to.
+ * @param entryCount Number of entries to read.
+ * @param entryOut Pointer to output directory entries to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ReadDirectory, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries);
+
+/**
+ * @brief Close a directory
+ * @param directory Directory to close.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CloseDirectory, FSPXI_Directory directory);
+
+/**
+ * @brief Opens an archive.
+ * @param archive Pointer to output the opened archive to.
+ * @param id ID of the archive.
+ * @param path Path of the archive.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(OpenArchive, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path);
+
+/**
+ * @brief Unknown 0x13
+ */
+DEFINE_PXIFS_SERVICE_METHOD(0x13, FSPXI_Archive archive, u8* out, FS_Path path);
+
+/**
+ * @brief Unknown 0x14
+ */
+DEFINE_PXIFS_SERVICE_METHOD(0x14, FSPXI_Archive archive, u32* out, FS_Path path);
+
+/**
+ * @brief Commits an archive's save data.
+ * @param archive Archive to commit.
+ * @param id Archive action sent by FSUSER_ControlArchive. Must not be 0 or 0x789D
+ * @remark Unsure why id is sent. This appears to be the default action for FSUSER_ControlArchive, with every action other than 0 and 0x789D being sent to this command.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CommitSaveData, FSPXI_Archive archive, u32 id);
+
+/**
+ * @brief Close an archive
+ * @param archive Archive to close.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CloseArchive, FSPXI_Archive archive);
+
+/**
+ * @brief Unknown 0x17. Appears to be an "is archive handle valid" command?
+ * @param archive Archive handle to check validity of.
+ * @param out Pointer to output validity to. 
+ */
+DEFINE_PXIFS_SERVICE_METHOD(0x17, FSPXI_Archive archive, bool* out);
+
+/**
+ * @brief Gets the inserted card type.
+ * @param out Pointer to output the card type to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetCardType, FS_CardType* out);
+
+/**
+ * @brief Gets the SDMC archive resource information.
+ * @param out Pointer to output the archive resource information to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSdmcArchiveResource, FS_ArchiveResource* out);
+
+/**
+ * @brief Gets the NAND archive resource information.
+ * @param out Pointer to output the archive resource information to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetNandArchiveResource, FS_ArchiveResource* out);
+
+/**
+ * @brief Gets the error code from the SDMC FatFS driver
+ * @param out Pointer to output the error code to
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSdmcFatFsError, u32* out);
+
+/**
+ * @brief Gets whether PXIFS0 detects the SD
+ * @param out Pointer to output the detection status to
+ */
+DEFINE_PXIFS_SERVICE_METHOD(IsSdmcDetected, bool* out);
+
+/**
+ * @brief Gets whether PXIFS0 can write to the SD
+ * @param out Pointer to output the writable status to
+ */
+DEFINE_PXIFS_SERVICE_METHOD(IsSdmcWritable, bool* out);
+
+/**
+ * @brief Gets the SDMC CID
+ * @param out Buffer to output the CID to.
+ * @param size Size of buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSdmcCid, void* out, u32 size);
+
+/**
+ * @brief Gets the NAND CID
+ * @param out Buffer to output the CID to.
+ * @param size Size of buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetNandCid, void* out, u32 size);
+
+/**
+ * @brief Gets the SDMC speed info
+ * @param out Buffer to output the speed info to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSdmcSpeedInfo, u32* out);
+
+/**
+ * @brief Gets the NAND speed info
+ * @param out Buffer to output the speed info to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetNandSpeedInfo, u32* out);
+
+/**
+ * @brief Gets the SDMC log
+ * @param out Buffer to output the log to.
+ * @param size Size of buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSdmcLog, void* out, u32 size);
+
+/**
+ * @brief Gets the NAND log
+ * @param out Buffer to output the log to.
+ * @param size Size of buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetNandLog, void* out, u32 size);
+
+/// Clears the SDMC log
+DEFINE_PXIFS_SERVICE_METHOD(ClearSdmcLog, void);
+
+/// Clears the NAND log
+DEFINE_PXIFS_SERVICE_METHOD(ClearNandLog, void);
+
+/**
+ * @brief Gets whether a card is inserted.
+ * @param inserted Pointer to output the insertion status to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardSlotIsInserted, bool* inserted);
+
+/**
+ * @brief Powers on the card slot.
+ * @param status Pointer to output the power status to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardSlotPowerOn, bool* status);
+
+/**
+ * @brief Powers off the card slot.
+ * @param status Pointer to output the power status to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardSlotPowerOff, bool* status);
+
+/**
+ * @brief Gets the card's power status.
+ * @param status Pointer to output the power status to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardSlotGetCardIFPowerStatus, bool* status);
+
+/**
+ * @brief Executes a CARDNOR direct command.
+ * @param commandId ID of the command.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCommand, u8 commandId);
+
+/**
+ * @brief Executes a CARDNOR direct command with an address.
+ * @param commandId ID of the command.
+ * @param address Address to provide.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCommandWithAddress, u8 commandId, u32 address);
+
+/**
+ * @brief Executes a CARDNOR direct read.
+ * @param commandId ID of the command.
+ * @param size Size of the output buffer.
+ * @param output Output buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectRead, u8 commandId, u32 size, u8* output);
+
+/**
+ * @brief Executes a CARDNOR direct read with an address.
+ * @param commandId ID of the command.
+ * @param address Address to provide.
+ * @param size Size of the output buffer.
+ * @param output Output buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectReadWithAddress, u8 commandId, u32 address, u32 size, u8* output);
+
+/**
+ * @brief Executes a CARDNOR direct write.
+ * @param commandId ID of the command.
+ * @param size Size of the input buffer.
+ * @param output Input buffer.
+ * @remark Stubbed in latest firmware, since ?.?.?
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectWrite, u8 commandId, u32 size, u8* input);
+
+/**
+ * @brief Executes a CARDNOR direct write with an address.
+ * @param commandId ID of the command.
+ * @param address Address to provide.
+ * @param size Size of the input buffer.
+ * @param input Input buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectWriteWithAddress, u8 commandId, u32 address, u32 size, u8* input);
+
+/**
+ * @brief Executes a CARDNOR 4xIO direct read.
+ * @param commandId ID of the command.
+ * @param address Address to provide.
+ * @param size Size of the output buffer.
+ * @param output Output buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectRead_4xIO, u8 commandId, u32 address, u32 size, u8* output);
+
+/**
+ * @brief Executes a CARDNOR direct CPU write without verify.
+ * @param address Address to provide.
+ * @param size Size of the input buffer.
+ * @param output Input buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCpuWriteWithoutVerify, u32 address, u32 size, u8* input);
+
+/**
+ * @brief Executes a CARDNOR direct sector erase without verify.
+ * @param address Address to provide.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectSectorEraseWithoutVerify, u32 address);
+
+/**
+ * @brief Gets an NCCH's product info
+ * @param info Pointer to output the product info to.
+ * @param archive Open NCCH content archive
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetProductInfo, FS_ProductInfo* info, FSPXI_Archive archive);
+
+/**
+ * @brief Sets the CARDSPI baud rate.
+ * @param baudRate Baud rate to set.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(SetCardSpiBaudrate, FS_CardSpiBaudRate baudRate);
+
+/**
+ * @brief Sets the CARDSPI bus mode.
+ * @param busMode Bus mode to set.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(SetCardSpiBusMode, FS_CardSpiBusMode busMode);
+
+/**
+ * @brief Sends initialization info to ARM9
+ * @param unk FS sends *(0x1FF81086)
+ */
+DEFINE_PXIFS_SERVICE_METHOD(SendInitializeInfoTo9, u8 unk);
+
+/**
+ * @brief Creates ext save data.
+ * @param info Info of the save data.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(CreateExtSaveData, FS_ExtSaveDataInfo info);
+
+/**
+ * @brief Deletes ext save data.
+ * @param info Info of the save data.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(DeleteExtSaveData, FS_ExtSaveDataInfo info);
+
+/**
+ * @brief Enumerates ext save data.
+ * @param idsWritten Pointer to output the number of IDs written to.
+ * @param idsSize Size of the IDs buffer.
+ * @param mediaType Media type to enumerate over.
+ * @param idSize Size of each ID element.
+ * @param shared Whether to enumerate shared ext save data.
+ * @param ids Pointer to output IDs to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(EnumerateExtSaveData, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids);
+
+/**
+ * @brief Gets a special content's index.
+ * @param index Pointer to output the index to.
+ * @param mediaType Media type of the special content.
+ * @param programId Program ID owning the special content.
+ * @param type Type of special content.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSpecialContentIndex, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type);
+
+/**
+ * @brief Gets the legacy ROM header of a program.
+ * @param mediaType Media type of the program.
+ * @param programId ID of the program.
+ * @param header Pointer to output the legacy ROM header to. (size = 0x3B4)
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetLegacyRomHeader, FS_MediaType mediaType, u64 programId, u8* header);
+
+/**
+ * @brief Gets the legacy banner data of a program.
+ * @param mediaType Media type of the program.
+ * @param programId ID of the program.
+ * @param banner Pointer to output the legacy banner data to. (size = 0x23C0)
+ * @param unk Unknown. Always 1?
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetLegacyBannerData, FS_MediaType mediaType, u64 programId, u8* banner, u32 unk);
+
+/**
+ * Unknown command 3D
+ * @param unk Unknown. Transaction?
+ */
+DEFINE_PXIFS_SERVICE_METHOD(0x3D, u32 unk);
+
+/// Deletes the 3DS SDMC root.
+DEFINE_PXIFS_SERVICE_METHOD(DeleteSdmcRoot, void);
+
+/// Deletes all ext save data on the NAND.
+DEFINE_PXIFS_SERVICE_METHOD(DeleteAllExtSaveDataOnNand, void);
+
+/// Initializes the CTR file system.
+DEFINE_PXIFS_SERVICE_METHOD(InitializeCtrFilesystem, void);
+
+/// Creates the FS seed.
+DEFINE_PXIFS_SERVICE_METHOD(CreateSeed, void);
+
+/**
+ * @brief Gets the CTR SDMC root path.
+ * @param out Pointer to output the root path to.
+ * @param length Length of the output buffer.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSdmcCtrRootPath, u8* out, u32 length);
+
+/**
+ * @brief Gets an archive's resource information.
+ * @param archiveResource Pointer to output the archive resource information to.
+ * @param mediaType System media type to check.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetArchiveResource, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType);
+
+/**
+ * @brief Exports the integrity verification seed.
+ * @param seed Pointer to output the seed to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ExportIntegrityVerificationSeed, FS_IntegrityVerificationSeed* seed);
+
+/**
+ * @brief Imports an integrity verification seed.
+ * @param seed Seed to import.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ImportIntegrityVerificationSeed, FS_IntegrityVerificationSeed* seed);
+
+/**
+ * @brief Gets the legacy sub banner data of a program.
+ * @param bannerSize Size of the banner.
+ * @param mediaType Media type of the program.
+ * @param programId ID of the program.
+ * @param header Pointer to output the legacy sub banner data to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetLegacySubBannerData, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner);
+
+/// Unknown command 47
+DEFINE_PXIFS_SERVICE_METHOD(0x47, void* buf, u32 size);
+
+/**
+ * @brief Gets the last modified time of a file in an archive.
+ * @param archive The archive that contains the file.
+ * @param out The pointer to write the timestamp to.
+ * @param path The UTF-16 path of the file.
+ * @param size The size of the path.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetFileLastModified, FSPXI_Archive archive, u64* out, u16* path, u32 size);
+
+/**
+ * @brief Reads from a special file.
+ * @param bytesRead Pointer to output the number of bytes read to.
+ * @param fileOffset Offset of the file.
+ * @param size Size of the buffer.
+ * @param data Buffer to read to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ReadSpecialFile, u32* bytesRead, u64 fileOffset, u32 size, u8* data);
+
+/**
+ * @brief Gets the size of a special file.
+ * @param fileSize Pointer to output the size to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(GetSpecialFileSize, u64* fileSize);
+
+/**
+ * @brief Initiates a device move as the source device.
+ * @param context Pointer to output the context to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(StartDeviceMoveAsSource, FS_DeviceMoveContext* context);
+
+/**
+ * @brief Initiates a device move as the destination device.
+ * @param context Context to use.
+ * @param clear Whether to clear the device's data first.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(StartDeviceMoveAsDestination, FS_DeviceMoveContext context, bool clear);
+
+/**
+ * @brief Reads data and stores SHA256 hashes of blocks
+ * @param file File to read from.
+ * @param bytesRead Pointer to output the number of read bytes to.
+ * @param offset Offset to read from.
+ * @param readBuffer Pointer to store read data in.
+ * @param readBufferSize Size of readBuffer.
+ * @param hashtable Pointer to store SHA256 hashes in.
+ * @param hashtableSize Size of hashtable.
+ * @param unk Unknown. Always 0x00001000?
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ReadFileSHA256, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk);
+
+/**
+ * @brief Assumedly writes data and stores SHA256 hashes of blocks
+ * @param file File to write to.
+ * @param bytesWritten Pointer to output the number of written bytes to.
+ * @param offset Offset to write to.
+ * @param writeBuffer Buffer to write from.
+ * @param writeBufferSize Size of writeBuffer.
+ * @param hashtable Pointer to store SHA256 hashes in.
+ * @param hashtableSize Size of hashtable
+ * @param unk1 Unknown. Might match with ReadFileSHA256's unknown?
+ * @param unk2 Unknown.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(WriteFileSHA256, FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2);
+
+/// Unknown command 4F
+DEFINE_PXIFS_SERVICE_METHOD(0x4F, u64 unk);
+
+/**
+ * @brief Sets the file system priority.
+ * @param priority Priority to set.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(SetPriority, u32 priority);
+
+/**
+ * @brief Toggles cleaning up invalid save data.
+ * @param enable Whether to enable cleaning up invalid save data.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(SwitchCleanupInvalidSaveData, bool enable);
+
+/**
+ * @brief Enumerates system save data.
+ * @param idsWritten Pointer to output the number of IDs written to.
+ * @param idsSize Size of the IDs buffer.
+ * @param ids Pointer to output IDs to.
+ */
+DEFINE_PXIFS_SERVICE_METHOD(EnumerateSystemSaveData, u32* idsWritten, u32 idsSize, u32* ids);
+
+/**
+ * @brief Reads the NAND report.
+ * @param unk Unknown
+ * @param buffer Buffer to write the report to.
+ * @param size Size of buffer
+ */
+DEFINE_PXIFS_SERVICE_METHOD(ReadNandReport, void* buffer, u32 size, u32 unk);
+
+/**
+ * @brief Unknown command 0x56
+ * @remark Called by FSUSER_ControlArchive with ArchiveAction 0x789D
+ */
+DEFINE_PXIFS_SERVICE_METHOD(0x56, u32 (*out)[4], FS_Archive archive, FS_Path path);
+
+#undef DEFINE_PXIFS_SERVICE_METHOD
+#undef DEFINE_SERVICE_METHOD

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -597,7 +597,7 @@ Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 un
  * @brief Unknown command 0x56
  * @remark Called by FSUSER_ControlArchive with ArchiveAction 0x789D
  */
-Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[static 4], FS_Archive archive, FS_Path path);
+Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[4], FS_Archive archive, FS_Path path);
 
 #undef DEFINE_PXIFS_SERVICE_METHOD
 #undef DEFINE_SERVICE_METHOD

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -431,7 +431,7 @@ Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaTy
  * @param programId ID of the program.
  * @param header Pointer to output the legacy ROM header to. (size = 0x3B4)
  */
-Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* header);
+Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* header);
 
 /**
  * @brief Gets the legacy banner data of a program.
@@ -440,7 +440,7 @@ Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u6
  * @param banner Pointer to output the legacy banner data to. (size = 0x23C0)
  * @param unk Unknown. Always 1?
  */
-Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* banner, u8 unk);
+Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* banner, u8 unk);
 
 /**
  * Unknown command 3D
@@ -493,7 +493,7 @@ Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_Inte
  * @param programId ID of the program.
  * @param header Pointer to output the legacy sub banner data to.
  */
-Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner);
+Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, void* banner);
 
 /// Unknown command 47
 Result FSPXI_Unknown0x47(Handle serviceHandle, void* buf, u32 size);
@@ -514,7 +514,7 @@ Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u6
  * @param size Size of the buffer.
  * @param data Buffer to read to.
  */
-Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, u8* data);
+Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, void* data);
 
 /**
  * @brief Gets the size of a special file.

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -11,48 +11,6 @@ typedef u64 FSPXI_Archive;
 typedef u64 FSPXI_File;
 typedef u64 FSPXI_Directory;
 
-#define DEFINE_SERVICE_METHOD(servname, funcname, ...) Result servname ## _ ## funcname(__VA_ARGS__)
-#define DEFINE_PXIFS_SERVICE_METHOD(funcname, ...) DEFINE_SERVICE_METHOD(PXIFS0, funcname, __VA_ARGS__); \
-                                                   DEFINE_SERVICE_METHOD(PXIFS1, funcname, __VA_ARGS__); \
-                                                   DEFINE_SERVICE_METHOD(PXIFSR, funcname, __VA_ARGS__); \
-                                                   DEFINE_SERVICE_METHOD(PXIFSB, funcname, __VA_ARGS__)
-
-/**
- * @brief Initializes PxiFS0.
- * @param servhandle Optional service session handle to use for PxiFS0, if zero srvGetServiceHandle() will be used.
- */
-Result pxifs0Init(Handle servhandle);
-
-/// Exits PxiFS0.
-void pxifs0Exit(void);
-
-/**
- * @brief Initializes PxiFS1.
- * @param servhandle Optional service session handle to use for PxiFS1, if zero srvGetServiceHandle() will be used.
- */
-Result pxifs1Init(Handle servhandle);
-
-/// Exits PxiFS1.
-void pxifs1Exit(void);
-
-/**
- * @brief Initializes PxiFSR.
- * @param servhandle Optional service session handle to use for PxiFSR, if zero srvGetServiceHandle() will be used.
- */
-Result pxifsRInit(Handle servhandle);
-
-/// Exits PxiFSR.
-void pxifsRExit(void);
-
-/**
- * @brief Initializes PxiFSB.
- * @param servhandle Optional service session handle to use for PxiFSB, if zero srvGetServiceHandle() will be used.
- */
-Result pxifsBInit(Handle servhandle);
-
-/// Exits PxiFSB.
-void pxifsBExit(void);
-
 /**
  * @brief Opens a file.
  * @param out Pointer to output the file handle to.
@@ -61,14 +19,14 @@ void pxifsBExit(void);
  * @param flags Flags to open the file with.
  * @param attributes Attributes of the file.
  */
-DEFINE_PXIFS_SERVICE_METHOD(OpenFile, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes);
+Result FSPXI_OpenFile(Handle serviceHandle, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes);
 
 /**
  * @brief Deletes a file.
  * @param archive Archive containing the file.
  * @param path Path of the file.
  */
-DEFINE_PXIFS_SERVICE_METHOD(DeleteFile, FSPXI_Archive archive, FS_Path path);
+Result FSPXI_DeleteFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path);
 
 /**
  * @brief Renames a file.
@@ -77,14 +35,14 @@ DEFINE_PXIFS_SERVICE_METHOD(DeleteFile, FSPXI_Archive archive, FS_Path path);
  * @param dstArchive Archive containing the destination file.
  * @param dstPath Path of the destination file.
  */
-DEFINE_PXIFS_SERVICE_METHOD(RenameFile, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath);
+Result FSPXI_RenameFile(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath);
 
 /**
  * @brief Deletes a directory.
  * @param archive Archive containing the directory.
  * @param path Path of the directory.
  */
-DEFINE_PXIFS_SERVICE_METHOD(DeleteDirectory, FSPXI_Archive archive, FS_Path path);
+Result FSPXI_DeleteDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path);
 
 /**
  * @brief Creates a file.
@@ -93,7 +51,7 @@ DEFINE_PXIFS_SERVICE_METHOD(DeleteDirectory, FSPXI_Archive archive, FS_Path path
  * @param attributes Attributes of the file.
  * @param size Size of the file.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CreateFile, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize);
+Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize);
 
 /**
  * @brief Creates a directory.
@@ -101,7 +59,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CreateFile, FSPXI_Archive archive, FS_Path path, u32
  * @param path Path of the directory.
  * @param attributes Attributes of the directory.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CreateDirectory, FSPXI_Archive archive, FS_Path path, u32 attributes);
+Result FSPXI_CreateDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes);
 
 /**
  * @brief Renames a directory.
@@ -110,7 +68,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CreateDirectory, FSPXI_Archive archive, FS_Path path
  * @param dstArchive Archive containing the destination directory.
  * @param dstPath Path of the destination directory.
  */
-DEFINE_PXIFS_SERVICE_METHOD(RenameDirectory, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath);
+Result FSPXI_RenameDirectory(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath);
 
 /**
  * @brief Opens a directory.
@@ -118,7 +76,7 @@ DEFINE_PXIFS_SERVICE_METHOD(RenameDirectory, FSPXI_Archive srcArchive, FS_Path s
  * @param archive Archive containing the directory.
  * @param path Path of the directory.
  */
-DEFINE_PXIFS_SERVICE_METHOD(OpenDirectory, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path);
+Result FSPXI_OpenDirectory(Handle serviceHandle, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path);
 
 /**
  * @brief Reads from a file.
@@ -128,7 +86,7 @@ DEFINE_PXIFS_SERVICE_METHOD(OpenDirectory, FSPXI_Directory* out, FSPXI_Archive a
  * @param buffer Buffer to read to.
  * @param size Size of the buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(ReadFile, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size);
+Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size);
 
 /**
  * @brief Calculate SHA256 of a file.
@@ -136,7 +94,7 @@ DEFINE_PXIFS_SERVICE_METHOD(ReadFile, FSPXI_File file, u32* bytesRead, u64 offse
  * @param buffer Buffer to output the hash to.
  * @param size Size of the buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CalculateFileHashSHA256, FSPXI_File file, u32* buffer, u32 size);
+Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, u32* buffer, u32 size);
 
 /**
  * @brief Writes to a file.
@@ -147,7 +105,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CalculateFileHashSHA256, FSPXI_File file, u32* buffe
  * @param size Size of the buffer.
  * @param flags Flags to use when writing.
  */
-DEFINE_PXIFS_SERVICE_METHOD(WriteFile, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags);
+Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags);
 
 /**
  * @brief Calculates the MAC used in a DISA/DIFF header?
@@ -157,27 +115,27 @@ DEFINE_PXIFS_SERVICE_METHOD(WriteFile, FSPXI_File file, u32* bytesWritten, u64 o
  * @param outBuffer Buffer to write MAC to.
  * @param outSize Size of outBuffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CalcSavegameMAC, FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize);
+Result FSPXI_CalcSavegameMAC(Handle serviceHandle, FSPXI_File file, const void* inBuffer, u32 inSize, void* outBuffer, u32 outSize);
 
 /**
  * @brief Get size of a file
  * @param file File to get the size of.
  * @param size Pointer to output size to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetFileSize, FSPXI_File file, u64* size);
+Result FSPXI_GetFileSize(Handle serviceHandle, FSPXI_File file, u64* size);
 
 /**
  * @brief Set size of a file
  * @param file File to set the size of
  * @param size Size to set the file to
  */
-DEFINE_PXIFS_SERVICE_METHOD(SetFileSize, FSPXI_File file, u64 size);
+Result FSPXI_SetFileSize(Handle serviceHandle, FSPXI_File file, u64 size);
 
 /**
  * @brief Close a file
  * @param file File to close
  */
-DEFINE_PXIFS_SERVICE_METHOD(CloseFile, FSPXI_File file);
+Result FSPXI_CloseFile(Handle serviceHandle, FSPXI_File file);
 
 /**
  * @brief Reads one or more directory entries.
@@ -186,13 +144,13 @@ DEFINE_PXIFS_SERVICE_METHOD(CloseFile, FSPXI_File file);
  * @param entryCount Number of entries to read.
  * @param entryOut Pointer to output directory entries to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(ReadDirectory, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries);
+Result FSPXI_ReadDirectory(Handle serviceHandle, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries);
 
 /**
  * @brief Close a directory
  * @param directory Directory to close.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CloseDirectory, FSPXI_Directory directory);
+Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directory);
 
 /**
  * @brief Opens an archive.
@@ -200,17 +158,17 @@ DEFINE_PXIFS_SERVICE_METHOD(CloseDirectory, FSPXI_Directory directory);
  * @param id ID of the archive.
  * @param path Path of the archive.
  */
-DEFINE_PXIFS_SERVICE_METHOD(OpenArchive, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path);
+Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path);
 
 /**
  * @brief Unknown 0x13
  */
-DEFINE_PXIFS_SERVICE_METHOD(0x13, FSPXI_Archive archive, u8* out, FS_Path path);
+Result FSPXI_Unknown0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, FS_Path path);
 
 /**
  * @brief Unknown 0x14
  */
-DEFINE_PXIFS_SERVICE_METHOD(0x14, FSPXI_Archive archive, u32* out, FS_Path path);
+Result FSPXI_Unknown0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, FS_Path path);
 
 /**
  * @brief Commits an archive's save data.
@@ -218,139 +176,139 @@ DEFINE_PXIFS_SERVICE_METHOD(0x14, FSPXI_Archive archive, u32* out, FS_Path path)
  * @param id Archive action sent by FSUSER_ControlArchive. Must not be 0 or 0x789D
  * @remark Unsure why id is sent. This appears to be the default action for FSUSER_ControlArchive, with every action other than 0 and 0x789D being sent to this command.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CommitSaveData, FSPXI_Archive archive, u32 id);
+Result FSPXI_CommitSaveData(Handle serviceHandle, FSPXI_Archive archive, u32 id);
 
 /**
  * @brief Close an archive
  * @param archive Archive to close.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CloseArchive, FSPXI_Archive archive);
+Result FSPXI_CloseArchive(Handle serviceHandle, FSPXI_Archive archive);
 
 /**
  * @brief Unknown 0x17. Appears to be an "is archive handle valid" command?
  * @param archive Archive handle to check validity of.
  * @param out Pointer to output validity to. 
  */
-DEFINE_PXIFS_SERVICE_METHOD(0x17, FSPXI_Archive archive, bool* out);
+Result FSPXI_Unknown0x17(Handle serviceHandle, FSPXI_Archive archive, bool* out);
 
 /**
  * @brief Gets the inserted card type.
  * @param out Pointer to output the card type to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetCardType, FS_CardType* out);
+Result FSPXI_GetCardType(Handle serviceHandle, FS_CardType* out);
 
 /**
  * @brief Gets the SDMC archive resource information.
  * @param out Pointer to output the archive resource information to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSdmcArchiveResource, FS_ArchiveResource* out);
+Result FSPXI_GetSdmcArchiveResource(Handle serviceHandle, FS_ArchiveResource* out);
 
 /**
  * @brief Gets the NAND archive resource information.
  * @param out Pointer to output the archive resource information to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetNandArchiveResource, FS_ArchiveResource* out);
+Result FSPXI_GetNandArchiveResource(Handle serviceHandle, FS_ArchiveResource* out);
 
 /**
  * @brief Gets the error code from the SDMC FatFS driver
  * @param out Pointer to output the error code to
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSdmcFatFsError, u32* out);
+Result FSPXI_GetSdmcFatFsError(Handle serviceHandle, u32* out);
 
 /**
  * @brief Gets whether PXIFS0 detects the SD
  * @param out Pointer to output the detection status to
  */
-DEFINE_PXIFS_SERVICE_METHOD(IsSdmcDetected, bool* out);
+Result FSPXI_IsSdmcDetected(Handle serviceHandle, bool* out);
 
 /**
  * @brief Gets whether PXIFS0 can write to the SD
  * @param out Pointer to output the writable status to
  */
-DEFINE_PXIFS_SERVICE_METHOD(IsSdmcWritable, bool* out);
+Result FSPXI_IsSdmcWritable(Handle serviceHandle, bool* out);
 
 /**
  * @brief Gets the SDMC CID
  * @param out Buffer to output the CID to.
  * @param size Size of buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSdmcCid, void* out, u32 size);
+Result FSPXI_GetSdmcCid(Handle serviceHandle, void* out, u32 size);
 
 /**
  * @brief Gets the NAND CID
  * @param out Buffer to output the CID to.
  * @param size Size of buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetNandCid, void* out, u32 size);
+Result FSPXI_GetNandCid(Handle serviceHandle, void* out, u32 size);
 
 /**
  * @brief Gets the SDMC speed info
  * @param out Buffer to output the speed info to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSdmcSpeedInfo, u32* out);
+Result FSPXI_GetSdmcSpeedInfo(Handle serviceHandle, u32* out);
 
 /**
  * @brief Gets the NAND speed info
  * @param out Buffer to output the speed info to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetNandSpeedInfo, u32* out);
+Result FSPXI_GetNandSpeedInfo(Handle serviceHandle, u32* out);
 
 /**
  * @brief Gets the SDMC log
  * @param out Buffer to output the log to.
  * @param size Size of buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSdmcLog, void* out, u32 size);
+Result FSPXI_GetSdmcLog(Handle serviceHandle, void* out, u32 size);
 
 /**
  * @brief Gets the NAND log
  * @param out Buffer to output the log to.
  * @param size Size of buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetNandLog, void* out, u32 size);
+Result FSPXI_GetNandLog(Handle serviceHandle, void* out, u32 size);
 
 /// Clears the SDMC log
-DEFINE_PXIFS_SERVICE_METHOD(ClearSdmcLog, void);
+Result FSPXI_ClearSdmcLog(Handle serviceHandle);
 
 /// Clears the NAND log
-DEFINE_PXIFS_SERVICE_METHOD(ClearNandLog, void);
+Result FSPXI_ClearNandLog(Handle serviceHandle);
 
 /**
  * @brief Gets whether a card is inserted.
  * @param inserted Pointer to output the insertion status to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardSlotIsInserted, bool* inserted);
+Result FSPXI_CardSlotIsInserted(Handle serviceHandle, bool* inserted);
 
 /**
  * @brief Powers on the card slot.
  * @param status Pointer to output the power status to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardSlotPowerOn, bool* status);
+Result FSPXI_CardSlotPowerOn(Handle serviceHandle, bool* status);
 
 /**
  * @brief Powers off the card slot.
  * @param status Pointer to output the power status to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardSlotPowerOff, bool* status);
+Result FSPXI_CardSlotPowerOff(Handle serviceHandle, bool* status);
 
 /**
  * @brief Gets the card's power status.
  * @param status Pointer to output the power status to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardSlotGetCardIFPowerStatus, bool* status);
+Result FSPXI_CardSlotGetCardIFPowerStatus(Handle serviceHandle, bool* status);
 
 /**
  * @brief Executes a CARDNOR direct command.
  * @param commandId ID of the command.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCommand, u8 commandId);
+Result FSPXI_CardNorDirectCommand(Handle serviceHandle, u8 commandId);
 
 /**
  * @brief Executes a CARDNOR direct command with an address.
  * @param commandId ID of the command.
  * @param address Address to provide.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCommandWithAddress, u8 commandId, u32 address);
+Result FSPXI_CardNorDirectCommandWithAddress(Handle serviceHandle, u8 commandId, u32 address);
 
 /**
  * @brief Executes a CARDNOR direct read.
@@ -358,7 +316,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCommandWithAddress, u8 commandId, u32 a
  * @param size Size of the output buffer.
  * @param output Output buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectRead, u8 commandId, u32 size, u8* output);
+Result FSPXI_CardNorDirectRead(Handle serviceHandle, u8 commandId, u32 size, void* output);
 
 /**
  * @brief Executes a CARDNOR direct read with an address.
@@ -367,7 +325,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectRead, u8 commandId, u32 size, u8* outpu
  * @param size Size of the output buffer.
  * @param output Output buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectReadWithAddress, u8 commandId, u32 address, u32 size, u8* output);
+Result FSPXI_CardNorDirectReadWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, void* output);
 
 /**
  * @brief Executes a CARDNOR direct write.
@@ -376,7 +334,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectReadWithAddress, u8 commandId, u32 addr
  * @param output Input buffer.
  * @remark Stubbed in latest firmware, since ?.?.?
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectWrite, u8 commandId, u32 size, u8* input);
+Result FSPXI_CardNorDirectWrite(Handle serviceHandle, u8 commandId, u32 size, const void* input);
 
 /**
  * @brief Executes a CARDNOR direct write with an address.
@@ -385,7 +343,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectWrite, u8 commandId, u32 size, u8* inpu
  * @param size Size of the input buffer.
  * @param input Input buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectWriteWithAddress, u8 commandId, u32 address, u32 size, u8* input);
+Result FSPXI_CardNorDirectWriteWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, const void* input);
 
 /**
  * @brief Executes a CARDNOR 4xIO direct read.
@@ -394,7 +352,7 @@ DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectWriteWithAddress, u8 commandId, u32 add
  * @param size Size of the output buffer.
  * @param output Output buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectRead_4xIO, u8 commandId, u32 address, u32 size, u8* output);
+Result FSPXI_CardNorDirectRead_4xIO(Handle serviceHandle, u8 commandId, u32 address, u32 size, void* output);
 
 /**
  * @brief Executes a CARDNOR direct CPU write without verify.
@@ -402,50 +360,50 @@ DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectRead_4xIO, u8 commandId, u32 address, u
  * @param size Size of the input buffer.
  * @param output Input buffer.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectCpuWriteWithoutVerify, u32 address, u32 size, u8* input);
+Result FSPXI_CardNorDirectCpuWriteWithoutVerify(Handle serviceHandle, u32 address, u32 size, const void* input);
 
 /**
  * @brief Executes a CARDNOR direct sector erase without verify.
  * @param address Address to provide.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CardNorDirectSectorEraseWithoutVerify, u32 address);
+Result FSPXI_CardNorDirectSectorEraseWithoutVerify(Handle serviceHandle, u32 address);
 
 /**
  * @brief Gets an NCCH's product info
  * @param info Pointer to output the product info to.
  * @param archive Open NCCH content archive
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetProductInfo, FS_ProductInfo* info, FSPXI_Archive archive);
+Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, FSPXI_Archive archive);
 
 /**
  * @brief Sets the CARDSPI baud rate.
  * @param baudRate Baud rate to set.
  */
-DEFINE_PXIFS_SERVICE_METHOD(SetCardSpiBaudrate, FS_CardSpiBaudRate baudRate);
+Result FSPXI_SetCardSpiBaudrate(Handle serviceHandle, FS_CardSpiBaudRate baudRate);
 
 /**
  * @brief Sets the CARDSPI bus mode.
  * @param busMode Bus mode to set.
  */
-DEFINE_PXIFS_SERVICE_METHOD(SetCardSpiBusMode, FS_CardSpiBusMode busMode);
+Result FSPXI_SetCardSpiBusMode(Handle serviceHandle, FS_CardSpiBusMode busMode);
 
 /**
  * @brief Sends initialization info to ARM9
  * @param unk FS sends *(0x1FF81086)
  */
-DEFINE_PXIFS_SERVICE_METHOD(SendInitializeInfoTo9, u8 unk);
+Result FSPXI_SendInitializeInfoTo9(Handle serviceHandle, u8 unk);
 
 /**
  * @brief Creates ext save data.
  * @param info Info of the save data.
  */
-DEFINE_PXIFS_SERVICE_METHOD(CreateExtSaveData, FS_ExtSaveDataInfo info);
+Result FSPXI_CreateExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info);
 
 /**
  * @brief Deletes ext save data.
  * @param info Info of the save data.
  */
-DEFINE_PXIFS_SERVICE_METHOD(DeleteExtSaveData, FS_ExtSaveDataInfo info);
+Result FSPXI_DeleteExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info);
 
 /**
  * @brief Enumerates ext save data.
@@ -456,7 +414,7 @@ DEFINE_PXIFS_SERVICE_METHOD(DeleteExtSaveData, FS_ExtSaveDataInfo info);
  * @param shared Whether to enumerate shared ext save data.
  * @param ids Pointer to output IDs to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(EnumerateExtSaveData, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids);
+Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids);
 
 /**
  * @brief Gets a special content's index.
@@ -465,7 +423,7 @@ DEFINE_PXIFS_SERVICE_METHOD(EnumerateExtSaveData, u32* idsWritten, u32 idsSize, 
  * @param programId Program ID owning the special content.
  * @param type Type of special content.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSpecialContentIndex, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type);
+Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type);
 
 /**
  * @brief Gets the legacy ROM header of a program.
@@ -473,7 +431,7 @@ DEFINE_PXIFS_SERVICE_METHOD(GetSpecialContentIndex, u16* index, FS_MediaType med
  * @param programId ID of the program.
  * @param header Pointer to output the legacy ROM header to. (size = 0x3B4)
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetLegacyRomHeader, FS_MediaType mediaType, u64 programId, u8* header);
+Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* header);
 
 /**
  * @brief Gets the legacy banner data of a program.
@@ -482,51 +440,51 @@ DEFINE_PXIFS_SERVICE_METHOD(GetLegacyRomHeader, FS_MediaType mediaType, u64 prog
  * @param banner Pointer to output the legacy banner data to. (size = 0x23C0)
  * @param unk Unknown. Always 1?
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetLegacyBannerData, FS_MediaType mediaType, u64 programId, u8* banner, u32 unk);
+Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* banner, u8 unk);
 
 /**
  * Unknown command 3D
  * @param unk Unknown. Transaction?
  */
-DEFINE_PXIFS_SERVICE_METHOD(0x3D, u32 unk);
+Result FSPXI_Unknown0x3D(Handle serviceHandle, u32 unk);
 
 /// Deletes the 3DS SDMC root.
-DEFINE_PXIFS_SERVICE_METHOD(DeleteSdmcRoot, void);
+Result FSPXI_DeleteSdmcRoot(Handle serviceHandle);
 
 /// Deletes all ext save data on the NAND.
-DEFINE_PXIFS_SERVICE_METHOD(DeleteAllExtSaveDataOnNand, void);
+Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle);
 
 /// Initializes the CTR file system.
-DEFINE_PXIFS_SERVICE_METHOD(InitializeCtrFilesystem, void);
+Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle);
 
 /// Creates the FS seed.
-DEFINE_PXIFS_SERVICE_METHOD(CreateSeed, void);
+Result FSPXI_CreateSeed(Handle serviceHandle);
 
 /**
  * @brief Gets the CTR SDMC root path.
  * @param out Pointer to output the root path to.
- * @param length Length of the output buffer.
+ * @param length Length of the output buffer in bytes.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSdmcCtrRootPath, u8* out, u32 length);
+Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u16* out, u32 length);
 
 /**
  * @brief Gets an archive's resource information.
  * @param archiveResource Pointer to output the archive resource information to.
  * @param mediaType System media type to check.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetArchiveResource, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType);
+Result FSPXI_GetArchiveResource(Handle serviceHandle, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType);
 
 /**
  * @brief Exports the integrity verification seed.
  * @param seed Pointer to output the seed to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(ExportIntegrityVerificationSeed, FS_IntegrityVerificationSeed* seed);
+Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed);
 
 /**
  * @brief Imports an integrity verification seed.
  * @param seed Seed to import.
  */
-DEFINE_PXIFS_SERVICE_METHOD(ImportIntegrityVerificationSeed, FS_IntegrityVerificationSeed* seed);
+Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_IntegrityVerificationSeed* seed);
 
 /**
  * @brief Gets the legacy sub banner data of a program.
@@ -535,10 +493,10 @@ DEFINE_PXIFS_SERVICE_METHOD(ImportIntegrityVerificationSeed, FS_IntegrityVerific
  * @param programId ID of the program.
  * @param header Pointer to output the legacy sub banner data to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetLegacySubBannerData, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner);
+Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner);
 
 /// Unknown command 47
-DEFINE_PXIFS_SERVICE_METHOD(0x47, void* buf, u32 size);
+Result FSPXI_Unknown0x47(Handle serviceHandle, void* buf, u32 size);
 
 /**
  * @brief Gets the last modified time of a file in an archive.
@@ -547,7 +505,7 @@ DEFINE_PXIFS_SERVICE_METHOD(0x47, void* buf, u32 size);
  * @param path The UTF-16 path of the file.
  * @param size The size of the path.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetFileLastModified, FSPXI_Archive archive, u64* out, u16* path, u32 size);
+Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u64* out, const u16* path, u32 size);
 
 /**
  * @brief Reads from a special file.
@@ -556,26 +514,26 @@ DEFINE_PXIFS_SERVICE_METHOD(GetFileLastModified, FSPXI_Archive archive, u64* out
  * @param size Size of the buffer.
  * @param data Buffer to read to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(ReadSpecialFile, u32* bytesRead, u64 fileOffset, u32 size, u8* data);
+Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, u8* data);
 
 /**
  * @brief Gets the size of a special file.
  * @param fileSize Pointer to output the size to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(GetSpecialFileSize, u64* fileSize);
+Result FSPXI_GetSpecialFileSize(Handle serviceHandle, u64* fileSize);
 
 /**
  * @brief Initiates a device move as the source device.
  * @param context Pointer to output the context to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(StartDeviceMoveAsSource, FS_DeviceMoveContext* context);
+Result FSPXI_StartDeviceMoveAsSource(Handle serviceHandle, FS_DeviceMoveContext* context);
 
 /**
  * @brief Initiates a device move as the destination device.
  * @param context Context to use.
  * @param clear Whether to clear the device's data first.
  */
-DEFINE_PXIFS_SERVICE_METHOD(StartDeviceMoveAsDestination, FS_DeviceMoveContext context, bool clear);
+Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_DeviceMoveContext context, bool clear);
 
 /**
  * @brief Reads data and stores SHA256 hashes of blocks
@@ -586,9 +544,9 @@ DEFINE_PXIFS_SERVICE_METHOD(StartDeviceMoveAsDestination, FS_DeviceMoveContext c
  * @param readBufferSize Size of readBuffer.
  * @param hashtable Pointer to store SHA256 hashes in.
  * @param hashtableSize Size of hashtable.
- * @param unk Unknown. Always 0x00001000?
+ * @param unk Unknown. Always 0x00001000? Possibly block size?
  */
-DEFINE_PXIFS_SERVICE_METHOD(ReadFileSHA256, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk);
+Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk);
 
 /**
  * @brief Assumedly writes data and stores SHA256 hashes of blocks
@@ -600,24 +558,24 @@ DEFINE_PXIFS_SERVICE_METHOD(ReadFileSHA256, FSPXI_File file, u32* bytesRead, u64
  * @param hashtable Pointer to store SHA256 hashes in.
  * @param hashtableSize Size of hashtable
  * @param unk1 Unknown. Might match with ReadFileSHA256's unknown?
- * @param unk2 Unknown.
+ * @param unk2 Unknown. Might match with ReadFileSHA256's unknown?
  */
-DEFINE_PXIFS_SERVICE_METHOD(WriteFileSHA256, FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2);
+Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2);
 
 /// Unknown command 4F
-DEFINE_PXIFS_SERVICE_METHOD(0x4F, u64 unk);
+Result FSPXI_Unknown0x4F(Handle serviceHandle, u64 unk);
 
 /**
  * @brief Sets the file system priority.
  * @param priority Priority to set.
  */
-DEFINE_PXIFS_SERVICE_METHOD(SetPriority, u32 priority);
+Result FSPXI_SetPriority(Handle serviceHandle, u32 priority);
 
 /**
  * @brief Toggles cleaning up invalid save data.
  * @param enable Whether to enable cleaning up invalid save data.
  */
-DEFINE_PXIFS_SERVICE_METHOD(SwitchCleanupInvalidSaveData, bool enable);
+Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enable);
 
 /**
  * @brief Enumerates system save data.
@@ -625,7 +583,7 @@ DEFINE_PXIFS_SERVICE_METHOD(SwitchCleanupInvalidSaveData, bool enable);
  * @param idsSize Size of the IDs buffer.
  * @param ids Pointer to output IDs to.
  */
-DEFINE_PXIFS_SERVICE_METHOD(EnumerateSystemSaveData, u32* idsWritten, u32 idsSize, u32* ids);
+Result FSPXI_EnumerateSystemSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, u32* ids);
 
 /**
  * @brief Reads the NAND report.
@@ -633,13 +591,13 @@ DEFINE_PXIFS_SERVICE_METHOD(EnumerateSystemSaveData, u32* idsWritten, u32 idsSiz
  * @param buffer Buffer to write the report to.
  * @param size Size of buffer
  */
-DEFINE_PXIFS_SERVICE_METHOD(ReadNandReport, void* buffer, u32 size, u32 unk);
+Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 unk);
 
 /**
  * @brief Unknown command 0x56
  * @remark Called by FSUSER_ControlArchive with ArchiveAction 0x789D
  */
-DEFINE_PXIFS_SERVICE_METHOD(0x56, u32 (*out)[4], FS_Archive archive, FS_Path path);
+Result FSPXI_Unknown0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive, FS_Path path);
 
 #undef DEFINE_PXIFS_SERVICE_METHOD
 #undef DEFINE_SERVICE_METHOD

--- a/libctru/include/3ds/services/fspxi.h
+++ b/libctru/include/3ds/services/fspxi.h
@@ -597,7 +597,7 @@ Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 un
  * @brief Unknown command 0x56
  * @remark Called by FSUSER_ControlArchive with ArchiveAction 0x789D
  */
-Result FSPXI_Unknown0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive, FS_Path path);
+Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[static 4], FS_Archive archive, FS_Path path);
 
 #undef DEFINE_PXIFS_SERVICE_METHOD
 #undef DEFINE_SERVICE_METHOD

--- a/libctru/source/services/fs.c
+++ b/libctru/source/services/fs.c
@@ -731,7 +731,7 @@ Result FSUSER_CardNorDirectCommandWithAddress(u8 commandId, u32 address)
 	return cmdbuf[1];
 }
 
-Result FSUSER_CardNorDirectRead(u8 commandId, u32 size, u8* output)
+Result FSUSER_CardNorDirectRead(u8 commandId, u32 size, void* output)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -747,7 +747,7 @@ Result FSUSER_CardNorDirectRead(u8 commandId, u32 size, u8* output)
 	return cmdbuf[1];
 }
 
-Result FSUSER_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output)
+Result FSUSER_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, void* output)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -764,7 +764,7 @@ Result FSUSER_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, 
 	return cmdbuf[1];
 }
 
-Result FSUSER_CardNorDirectWrite(u8 commandId, u32 size, u8* input)
+Result FSUSER_CardNorDirectWrite(u8 commandId, u32 size, const void* input)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -780,7 +780,7 @@ Result FSUSER_CardNorDirectWrite(u8 commandId, u32 size, u8* input)
 	return cmdbuf[1];
 }
 
-Result FSUSER_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input)
+Result FSUSER_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, const void* input)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -797,7 +797,7 @@ Result FSUSER_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size,
 	return cmdbuf[1];
 }
 
-Result FSUSER_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output)
+Result FSUSER_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, void* output)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -814,7 +814,7 @@ Result FSUSER_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* ou
 	return cmdbuf[1];
 }
 
-Result FSUSER_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input)
+Result FSUSER_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, const void* input)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -929,7 +929,7 @@ Result FSUSER_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 pro
 	return cmdbuf[1];
 }
 
-Result FSUSER_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header)
+Result FSUSER_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, void* header)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -946,7 +946,7 @@ Result FSUSER_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* head
 	return cmdbuf[1];
 }
 
-Result FSUSER_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner)
+Result FSUSER_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, void* banner)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -1084,7 +1084,7 @@ Result FSUSER_GetFormatInfo(u32* totalSize, u32* directories, u32* files, bool* 
 	return cmdbuf[1];
 }
 
-Result FSUSER_GetLegacyRomHeader2(u32 headerSize, FS_MediaType mediaType, u64 programId, u8* header)
+Result FSUSER_GetLegacyRomHeader2(u32 headerSize, FS_MediaType mediaType, u64 programId, void* header)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -1183,7 +1183,7 @@ Result FSUSER_FormatSaveData(FS_ArchiveID archiveId, FS_Path path, u32 blocks, u
 	return cmdbuf[1];
 }
 
-Result FSUSER_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner)
+Result FSUSER_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, void* banner)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 
@@ -1246,7 +1246,7 @@ Result FSUSER_UpdateSha256Context(const void* data, u32 inputSize, u8* hash)
 	return cmdbuf[1];
 }
 
-Result FSUSER_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data)
+Result FSUSER_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, void* data)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();
 

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -968,7 +968,7 @@ Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaTy
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* header)
+Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* header)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -985,7 +985,7 @@ Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u6
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* banner, u8 unk)
+Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* banner, u8 unk)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1123,7 +1123,7 @@ Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_Inte
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner)
+Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, void* banner)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1175,7 +1175,7 @@ Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u6
     return (Result) cmdbuf[1];
 }
 
-Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, u8* data)
+Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, void* data)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -1362,7 +1362,7 @@ Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 un
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[static 4], FS_Archive archive, FS_Path path)
+Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[4], FS_Archive archive, FS_Path path)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -1362,7 +1362,7 @@ Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 un
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive, FS_Path path)
+Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[static 4], FS_Archive archive, FS_Path path)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1377,10 +1377,10 @@ Result FSPXI_Unknown0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive
 
     if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    (*out)[0] = cmdbuf[2];
-    (*out)[1] = cmdbuf[3];
-    (*out)[2] = cmdbuf[4];
-    (*out)[3] = cmdbuf[5];
+    out[0] = cmdbuf[2];
+    out[1] = cmdbuf[3];
+    out[2] = cmdbuf[4];
+    out[3] = cmdbuf[5];
 
     return (Result) cmdbuf[1];
 }

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -1,0 +1,1906 @@
+#include <string.h>
+#include <3ds/ipc.h>
+#include <3ds/result.h>
+#include <3ds/services/fspxi.h>
+#include <3ds/srv.h>
+#include <3ds/svc.h>
+#include <3ds/synchronization.h>
+#include <3ds/types.h>
+
+static Handle pxifs0Handle;
+static int pxifs0RefCount;
+
+static Handle pxifs1Handle;
+static int pxifs1RefCount;
+
+static Handle pxifsRHandle;
+static int pxifsRRefCount;
+
+static Handle pxifsBHandle;
+static int pxifsBRefCount;
+
+Result pxifs0Init(Handle servhandle)
+{
+     Result res=0;
+     if (AtomicPostIncrement(&pxifs0RefCount)) return 0;
+     if (servhandle)
+     {
+         pxifs0Handle = servhandle;
+     }
+     else
+     {
+         res = srvGetServiceHandle(&pxifs0Handle, "PxiFS0");
+         if (R_FAILED(res)) AtomicDecrement(&pxifs0RefCount);
+     }
+     return res;
+}
+
+Result pxifs1Init(Handle servhandle)
+{
+     Result res=0;
+     if (AtomicPostIncrement(&pxifs1RefCount)) return 0;
+     if (servhandle)
+     {
+         pxifs1Handle = servhandle;
+     }
+     else
+     {
+         res = srvGetServiceHandle(&pxifs1Handle, "PxiFS1");
+         if (R_FAILED(res)) AtomicDecrement(&pxifs1RefCount);
+     }
+     return res;
+}
+
+Result pxifsRInit(Handle servhandle)
+{
+     Result res=0;
+     if (AtomicPostIncrement(&pxifsRRefCount)) return 0;
+     if (servhandle)
+     {
+         pxifsRHandle = servhandle;
+     }
+     else
+     {
+         res = srvGetServiceHandle(&pxifsRHandle, "PxiFSR");
+         if (R_FAILED(res)) AtomicDecrement(&pxifsRRefCount);
+     }
+     return res;
+}
+
+Result pxifsBInit(Handle servhandle)
+{
+     Result res=0;
+     if (AtomicPostIncrement(&pxifsBRefCount)) return 0;
+     if (servhandle)
+     {
+         pxifsBHandle = servhandle;
+     }
+     else
+     {
+         res = srvGetServiceHandle(&pxifsBHandle, "PxiFSB");
+         if (R_FAILED(res)) AtomicDecrement(&pxifsBRefCount);
+     }
+     return res;
+}
+
+void pxifs0Exit(void)
+{
+    if (AtomicDecrement(&pxifs0RefCount)) return;
+    svcCloseHandle(pxifs0Handle);
+}
+
+void pxifs1Exit(void)
+{
+    if (AtomicDecrement(&pxifs1RefCount)) return;
+    svcCloseHandle(pxifs1Handle);
+}
+
+void pxifsRExit(void)
+{
+    if (AtomicDecrement(&pxifsRRefCount)) return;
+    svcCloseHandle(pxifsRHandle);
+}
+
+void pxifsBExit(void)
+{
+    if (AtomicDecrement(&pxifsBRefCount)) return;
+    svcCloseHandle(pxifsBHandle);
+}
+
+static Result FSPXI_OpenFile(Handle serviceHandle, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1, 7, 2); // 0x000101C2
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) archive;
+    cmdbuf[3] = (u32)(archive >> 32);
+    cmdbuf[4] = path.type;
+    cmdbuf[5] = path.size;
+    cmdbuf[6] = flags;
+    cmdbuf[7] = attributes;
+    cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[9] = (u32) path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_DeleteFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x2, 5, 2); // 0x00020142
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) archive;
+    cmdbuf[3] = (u32)(archive >> 32);
+    cmdbuf[4] = path.type;
+    cmdbuf[5] = path.size;
+    cmdbuf[6] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[7] = (u32) path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_RenameFile(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3, 9, 4); // 0x00030244
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) srcArchive;
+    cmdbuf[3] = (u32)(srcArchive >> 32);
+    cmdbuf[4] = srcPath.type;
+    cmdbuf[5] = srcPath.size;
+    cmdbuf[6] = (u32) dstArchive;
+    cmdbuf[7] = (u32)(dstArchive >> 32);
+    cmdbuf[8] = dstPath.type;
+    cmdbuf[9] = dstPath.size;
+    cmdbuf[10] = IPC_Desc_PXIBuffer(srcPath.size, 0, true);
+    cmdbuf[11] = (u32) srcPath.data;
+    cmdbuf[12] = IPC_Desc_PXIBuffer(dstPath.size, 1, true);
+    cmdbuf[13] = (u32) dstPath.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_DeleteDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x4, 5, 2); // 0x00040142
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) archive;
+    cmdbuf[3] = (u32)(archive >> 32);
+    cmdbuf[4] = path.type;
+    cmdbuf[5] = path.size;
+    cmdbuf[6] = IPC_Desc_PXIBuffer(path.size, 0, false);
+    cmdbuf[7] = (u32) path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x5, 8, 2); // 0x00050202
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) archive;
+    cmdbuf[3] = (u32)(archive >> 32);
+    cmdbuf[4] = path.type;
+    cmdbuf[5] = path.size;
+    cmdbuf[6] = attributes;
+    cmdbuf[7] = (u32)fileSize;
+    cmdbuf[8] = (u32)(fileSize >> 32);
+    cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[9] = (u32) path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CreateDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x6, 6, 2); // 0x00060182
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) archive;
+    cmdbuf[3] = (u32)(archive >> 32);
+    cmdbuf[4] = path.type;
+    cmdbuf[5] = path.size;
+    cmdbuf[6] = attributes;
+    cmdbuf[7] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[8] = (u32) path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_RenameDirectory(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x7, 9, 4); // 0x00070244
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) srcArchive;
+    cmdbuf[3] = (u32)(srcArchive >> 32);
+    cmdbuf[4] = srcPath.type;
+    cmdbuf[5] = srcPath.size;
+    cmdbuf[6] = (u32) dstArchive;
+    cmdbuf[7] = (u32)(dstArchive >> 32);
+    cmdbuf[8] = dstPath.type;
+    cmdbuf[9] = dstPath.size;
+    cmdbuf[10] = IPC_Desc_PXIBuffer(srcPath.size, 0, true);
+    cmdbuf[11] = (u32) srcPath.data;
+    cmdbuf[12] = IPC_Desc_PXIBuffer(dstPath.size, 1, true);
+    cmdbuf[13] = (u32) dstPath.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_OpenDirectory(Handle serviceHandle, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x8, 4, 2); // 0x00080102
+    cmdbuf[1] = 0; // transaction
+    cmdbuf[2] = (u32) archive;
+    cmdbuf[3] = (u32)(archive >> 32);
+    cmdbuf[4] = path.type;
+    cmdbuf[5] = path.size;
+    cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[9] = (u32) path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x9, 5, 2); // 0x00090142
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32)(file >> 32);
+    cmdbuf[3] = (u32) offset;
+    cmdbuf[4] = (u32)(offset >> 32);
+    cmdbuf[5] = size;
+    cmdbuf[6] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[7] = (u32) buffer;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(bytesRead) *bytesRead = cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, u32* buffer, u32 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0xA, 3, 2); // 0x000A00C2
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32)(file >> 32);
+    cmdbuf[3] = size;
+    cmdbuf[4] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[5] = (u32) buffer;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0xB,6,2); // 0x000B0182
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32)(file >> 32);
+	cmdbuf[3] = (u32) offset;
+	cmdbuf[4] = (u32) (offset >> 32);
+	cmdbuf[5] = flags;
+	cmdbuf[6] = size;
+	cmdbuf[7] = IPC_Desc_PXIBuffer(size, 0, true);
+	cmdbuf[8] = (u32) buffer;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	if(bytesWritten) *bytesWritten = cmdbuf[2];
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CalcSavegameMAC(Handle serviceHandle, FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0xC, 4, 4);
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32)(file >> 32);
+    cmdbuf[3] = outSize;
+    cmdbuf[4] = inSize;
+    cmdbuf[5] = IPC_Desc_PXIBuffer(inSize, 0, true);
+    cmdbuf[6] = (u32) inBuffer;
+    cmdbuf[7] = IPC_Desc_PXIBuffer(outSize, 1, false);
+    cmdbuf[8] = (u32) outBuffer;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetFileSize(Handle serviceHandle, FSPXI_File file, u64* size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0xD, 2, 0); // 0x000D0080
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32) (file >> 32);
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (size) *size = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_SetFileSize(Handle serviceHandle, FSPXI_File file, u64 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0xE, 4, 0); // 0x000E0100
+    cmdbuf[1] = (u32) size;
+    cmdbuf[2] = (u32) (size >> 32);
+    cmdbuf[3] = (u32) file;
+    cmdbuf[4] = (u32) (file >> 32);
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CloseFile(Handle serviceHandle, FSPXI_File file)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0xF, 2, 0); // 0x000F0080
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32) (file >> 32);
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ReadDirectory(Handle serviceHandle, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x10, 3, 2); // 0x001000C2
+    cmdbuf[1] = (u32) directory;
+    cmdbuf[2] = (u32) (directory >> 32);
+    cmdbuf[3] = entryCount;
+    cmdbuf[4] = IPC_Desc_PXIBuffer(sizeof(FS_DirectoryEntry) * entryCount, 0, false);
+    cmdbuf[5] = (u32) entries;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(entriesRead) *entriesRead = cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directory)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x11, 2, 0); // 0x00110080
+    cmdbuf[1] = (u32) directory;
+    cmdbuf[2] = (u32) (directory >> 32);
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path)
+{
+    if (!archive) return -2;
+
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x12, 3, 2);
+    cmdbuf[1] = archiveID;
+    cmdbuf[2] = path.type;
+    cmdbuf[3] = path.size;
+    cmdbuf[4] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[5] = (u32)path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    *archive = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, FS_Path path)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x13, 4, 2); // 0x00130102
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+    cmdbuf[3] = path.type;
+    cmdbuf[4] = path.size;
+    cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[6] = (u32)path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (out) *out = (u8)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, FS_Path path)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x14, 4, 2); // 0x00140102
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+    cmdbuf[3] = path.type;
+    cmdbuf[4] = path.size;
+    cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[6] = (u32)path.data;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (out) *out = (u8)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CommitSaveData(Handle serviceHandle, FSPXI_Archive archive, u32 id)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x15, 3, 0); // 0x001500C0
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+    cmdbuf[3] = id;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CloseArchive(Handle serviceHandle, FSPXI_Archive archive)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x16, 2, 0); // 0x00160080
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x17(Handle serviceHandle, FSPXI_Archive archive, bool* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x17, 2, 0); // 0x00170080
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (out) *out = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetCardType(Handle serviceHandle, FS_CardType* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x18, 0, 0); // 0x00180000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out) *out = cmdbuf[2] & 0xFF;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSdmcArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x19, 0, 0); // 0x00190000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out)
+    {
+        out->sectorSize = cmdbuf[2];
+        out->clusterSize = cmdbuf[3];
+        out->totalClusters = cmdbuf[4];
+        out->freeClusters = cmdbuf[5];
+    }
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetNandArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1A, 0, 0); // 0x001A0000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out)
+    {
+        out->sectorSize = cmdbuf[2];
+        out->clusterSize = cmdbuf[3];
+        out->totalClusters = cmdbuf[4];
+        out->freeClusters = cmdbuf[5];
+    }
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSdmcFatFsError(Handle serviceHandle, u32* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1B, 0, 0); // 0x001B0000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out) *out = cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_IsSdmcDetected(Handle serviceHandle, bool* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1C, 0, 0); // 0x001C0000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out) *out = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_IsSdmcWritable(Handle serviceHandle, bool* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1D, 0, 0); // 0x001D0000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out) *out = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSdmcCid(Handle serviceHandle, void* out, u32 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1E, 0, 0); // 0x001E0000
+    cmdbuf[1] = size;
+    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[3] = (u32) out;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetNandCid(Handle serviceHandle, void* out, u32 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x1F, 0, 0); // 0x001F0000
+    cmdbuf[1] = size;
+    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[3] = (u32) out;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSdmcSpeedInfo(Handle serviceHandle, u32* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x20, 0, 0); // 0x00200000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out) *out = cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetNandSpeedInfo(Handle serviceHandle, u32* out)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x21, 0, 0); // 0x00210000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(out) *out = cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSdmcLog(Handle serviceHandle, void* out, u32 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x22, 1, 2); // 0x00220042
+    cmdbuf[1] = size;
+    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[3] = (u32) out;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetNandLog(Handle serviceHandle, void* out, u32 size)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x23, 1, 2); // 0x00230042
+    cmdbuf[1] = size;
+    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[3] = (u32) out;
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ClearSdmcLog(Handle serviceHandle)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x24, 0, 0); // 0x00240000
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ClearNandLog(Handle serviceHandle)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x25, 0, 0); // 0x00250000
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardSlotIsInserted(Handle serviceHandle, bool* inserted)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x26, 0, 0); // 0x00260000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(inserted) *inserted = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardSlotPowerOn(Handle serviceHandle, bool* status)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x27, 0, 0); // 0x00270000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(status) *status = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardSlotPowerOff(Handle serviceHandle, bool* status)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x28, 0, 0); // 0x00280000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(status) *status = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardSlotGetCardIFPowerStatus(Handle serviceHandle, bool* status)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x29, 0, 0); // 0x00290000
+
+    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(status) *status = (bool)cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectCommand(Handle serviceHandle, u8 commandId)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2A, 1, 0); // 0x002A0040
+	cmdbuf[1] = commandId;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectCommandWithAddress(Handle serviceHandle, u8 commandId, u32 address)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2B, 2, 0); // 0x002B0080
+	cmdbuf[1] = commandId;
+	cmdbuf[2] = address;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectRead(Handle serviceHandle, u8 commandId, u32 size, u8* output)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2C, 2, 2); // 0x002C0082
+	cmdbuf[1] = commandId;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_PXIBuffer(size * sizeof(u32), 0, false);
+	cmdbuf[4] = (u32) output;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectReadWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, u8* output)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2D, 3, 2); // 0x002D00C2
+	cmdbuf[1] = commandId;
+	cmdbuf[2] = address;
+	cmdbuf[3] = size;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(size * sizeof(u32), 0, false);
+	cmdbuf[5] = (u32) output;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectWrite(Handle serviceHandle, u8 commandId, u32 size, u8* input)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2E, 2, 2); // 0x002E0082
+	cmdbuf[1] = commandId;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_PXIBuffer(size * sizeof(u32), 0, true);
+	cmdbuf[4] = (u32) input;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectWriteWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, u8* input)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2F, 3, 2); // 0x002F00C2
+	cmdbuf[1] = commandId;
+	cmdbuf[2] = address;
+	cmdbuf[3] = size;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(size * sizeof(u32), 0, true);
+	cmdbuf[5] = (u32) input;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectRead_4xIO(Handle serviceHandle, u8 commandId, u32 address, u32 size, u8* output)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x30, 3, 2); // 0x003000C2
+	cmdbuf[1] = commandId;
+	cmdbuf[2] = address;
+	cmdbuf[3] = size;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(size * sizeof(u32), 0, false);
+	cmdbuf[5] = (u32) output;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectCpuWriteWithoutVerify(Handle serviceHandle, u32 address, u32 size, u8* input)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x31, 2, 2); // 0x00310082
+	cmdbuf[1] = address;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_PXIBuffer(size * sizeof(u32), 0, true);
+	cmdbuf[4] = (u32) input;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CardNorDirectSectorEraseWithoutVerify(Handle serviceHandle, u32 address)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x32, 1, 0); // 0x00320040
+	cmdbuf[1] = address;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, FSPXI_Archive archive)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x33, 2, 0); // 0x00330080
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32)(archive >> 32);
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(info) memcpy(info, &cmdbuf[2], sizeof(FS_ProductInfo));
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_SetCardSpiBaudrate(Handle serviceHandle, FS_CardSpiBaudRate baudRate)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x34, 1, 0); // 0x00340040
+    cmdbuf[1] = baudRate;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_SetCardSpiBusMode(Handle serviceHandle, FS_CardSpiBusMode busMode)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x35, 1, 0); // 0x00350040
+    cmdbuf[1] = busMode;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_SendInitializeInfoTo9(Handle serviceHandle, u8 unk)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x36, 1, 0); // 0x00360040
+    cmdbuf[1] = unk;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CreateExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x37, 4, 0);
+    memcpy(&cmdbuf[1], &info, sizeof(FS_ExtSaveDataInfo));
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_DeleteExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
+{
+    Result ret = 0;
+    u32* cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x38, 4, 0);
+    memcpy(&cmdbuf[1], &info, sizeof(FS_ExtSaveDataInfo));
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x39, 4, 2); // 0x00390102
+	cmdbuf[1] = idsSize;
+	cmdbuf[2] = mediaType;
+	cmdbuf[3] = idSize;
+	cmdbuf[4] = shared;
+	cmdbuf[5] = IPC_Desc_Buffer(idsSize, IPC_BUFFER_W);
+	cmdbuf[6] = (u32) ids;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	if(idsWritten) *idsWritten = cmdbuf[2];
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3A, 4, 0); // 0x003A0100
+	cmdbuf[1] = mediaType;
+	cmdbuf[2] = (u32) programId;
+	cmdbuf[3] = (u32) (programId >> 32);
+	cmdbuf[4] = type;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	if(index) *index = cmdbuf[2];
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* header)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3B, 3, 2); // 0x003B00C2
+    cmdbuf[1] = mediaType;
+	cmdbuf[2] = (u32) programId;
+	cmdbuf[3] = (u32) (programId >> 32);
+    cmdbuf[4] = IPC_Desc_PXIBuffer(0x378, 0, false);
+    cmdbuf[5] = (u32) header;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* banner, u8 unk)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3C, 4, 2); // 0x003C0102
+    cmdbuf[1] = mediaType;
+	cmdbuf[2] = (u32) programId;
+	cmdbuf[3] = (u32) (programId >> 32);
+    cmdbuf[4] = unk;
+    cmdbuf[5] = IPC_Desc_PXIBuffer(0x23c0, 0, false);
+    cmdbuf[6] = (u32) banner;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x3D(Handle serviceHandle, u32 unk)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3D, 1, 0); // 0x003D0040
+    cmdbuf[1] = unk;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_DeleteSdmcRoot(Handle serviceHandle)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3E, 0, 0); // 0x003E0000
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x3F, 1, 0); // 0x003F0000
+    cmdbuf[1] = 0; // Transaction
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x40, 0, 0); // 0x00400000
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_CreateSeed(Handle serviceHandle)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x41, 0, 0); // 0x00410000
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u8* out, u32 length)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x42, 1, 2); // 0x00420042
+	cmdbuf[1] = length;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(length, 0, false);
+	cmdbuf[3] = (u32) out;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetArchiveResource(Handle serviceHandle, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+    
+	cmdbuf[0] = IPC_MakeHeader(0x43, 1, 0); // 0x00430040
+	cmdbuf[1] = mediaType;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    memcpy(archiveResource, &cmdbuf[2], sizeof(FS_ArchiveResource));
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x44, 0, 2); // 0x00440002
+    cmdbuf[1] = IPC_Desc_PXIBuffer(0x130, 0, false);
+    cmdbuf[2] = (u32)seed;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x45, 0, 2); // 0x00450002
+    cmdbuf[1] = IPC_Desc_PXIBuffer(0x130, 0, true);
+    cmdbuf[2] = (u32)seed;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x46, 4, 2); // 0x00460102
+	cmdbuf[1] = bannerSize;
+	cmdbuf[2] = mediaType;
+	cmdbuf[3] = (u32) programId;
+	cmdbuf[4] = (u32) (programId >> 32);
+	cmdbuf[5] = IPC_Desc_PXIBuffer(bannerSize, 0, false);
+	cmdbuf[6] = (u32) banner;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x47(Handle serviceHandle, void* buf, u32 size)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x47, 1, 2); // 0x00470042
+    cmdbuf[1] = size;
+    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[3] = (u32) buf;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u64* out, u16* path, u32 size)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x48, 3, 2); // 0x004800C2
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+    cmdbuf[3] = size;
+    cmdbuf[4] = IPC_Desc_PXIBuffer(size, 0, true);
+    cmdbuf[5] = (u32) path;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, u8* data)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+    
+    cmdbuf[0] = IPC_MakeHeader(0x49, 4, 2); // 0x00490102
+	cmdbuf[1] = 0;
+	cmdbuf[2] = (u32) fileOffset;
+	cmdbuf[3] = (u32) (fileOffset >> 32);
+	cmdbuf[4] = size;
+	cmdbuf[5] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[6] = (u32) data;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (bytesRead) *bytesRead = cmdbuf[2];
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_GetSpecialFileSize(Handle serviceHandle, u64* fileSize)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x4A, 1, 0); // 0x004A0040
+    cmdbuf[1] = 0; // Must be 0
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (fileSize) *fileSize = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_StartDeviceMoveAsSource(Handle serviceHandle, FS_DeviceMoveContext* context)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x4B, 0, 0); // 0x004B0000
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if(context) memcpy(context, &cmdbuf[2], sizeof(FS_DeviceMoveContext));
+
+    return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_DeviceMoveContext context, bool clear)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x4C, 9, 0); // 0x004C0240
+	memcpy(&cmdbuf[1], &context, sizeof(FS_DeviceMoveContext));
+	cmdbuf[9] = clear;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x4D, 7, 4); // 0x004D01C4
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32) (file >> 32);
+    cmdbuf[3] = (u32) offset;
+    cmdbuf[4] = (u32) (offset >> 32);
+    cmdbuf[5] = readBufferSize;
+    cmdbuf[6] = unk;
+    cmdbuf[7] = hashtableSize;
+    cmdbuf[8] = IPC_Desc_PXIBuffer(hashtableSize, 0, true);
+    cmdbuf[9] = (u32) hashtable;
+    cmdbuf[10] = IPC_Desc_PXIBuffer(readBufferSize, 1, false);
+    cmdbuf[11] = (u32) readBuffer;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (bytesRead) *bytesRead = cmdbuf[2];
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x4E, 8, 4); // 0x004E0204
+    cmdbuf[1] = (u32) file;
+    cmdbuf[2] = (u32) (file >> 32);
+    cmdbuf[3] = (u32) offset;
+    cmdbuf[4] = (u32) (offset >> 32);
+    cmdbuf[5] = writeBufferSize;
+    cmdbuf[6] = unk1;
+    cmdbuf[7] = hashtableSize;
+    cmdbuf[8] = unk2;
+    cmdbuf[9] = IPC_Desc_PXIBuffer(hashtableSize, 0, true);
+    cmdbuf[10] = (u32) hashtable;
+    cmdbuf[11] = IPC_Desc_PXIBuffer(writeBufferSize, 1, false);
+    cmdbuf[12] = (u32) writeBuffer;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (bytesWritten) *bytesWritten = cmdbuf[2];
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x4F(Handle serviceHandle, u64 unk)
+{
+	Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x4F, 2, 0); // 0x004F0080
+    cmdbuf[1] = (u32) unk;
+    cmdbuf[2] = (u32) (unk >> 32);
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_SetPriority(Handle serviceHandle, u32 priority)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x50, 1, 0); // 0x00500040
+    cmdbuf[1] = priority;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enable)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x51, 1, 0); // 0x00500040
+    cmdbuf[1] = enable;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_EnumerateSystemSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, u32* ids)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x54, 1, 2); // 0x00540042
+    cmdbuf[1] = idsSize;
+    cmdbuf[2] = IPC_Desc_PXIBuffer(idsSize, 0, false);
+    cmdbuf[3] = (u32) ids;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    if (idsWritten) *idsWritten = cmdbuf[2];
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 unk)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x55, 2, 2); // 0x00550082
+    cmdbuf[1] = size;
+    cmdbuf[2] = unk;
+    cmdbuf[3] = IPC_Desc_PXIBuffer(size, 0, false);
+    cmdbuf[4] = (u32) buffer;
+
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+	return (Result) cmdbuf[1];
+}
+
+static Result FSPXI_0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive, FS_Path path)
+{
+    Result ret = 0;
+    u32 *cmdbuf = getThreadCommandBuffer();
+
+    cmdbuf[0] = IPC_MakeHeader(0x56, 4, 2); // 0x00560102
+    cmdbuf[1] = (u32) archive;
+    cmdbuf[2] = (u32) (archive >> 32);
+    cmdbuf[3] = path.type;
+    cmdbuf[4] = path.size;
+    cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
+    cmdbuf[6] = (u32)path.data;
+
+    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+
+    (*out)[0] = cmdbuf[2];
+    (*out)[1] = cmdbuf[3];
+    (*out)[2] = cmdbuf[4];
+    (*out)[3] = cmdbuf[5];
+
+    return (Result) cmdbuf[1];
+}
+
+Result PXIFS0_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifs0Handle, out, archive, path, flags, attributes); }
+Result PXIFS1_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifs1Handle, out, archive, path, flags, attributes); }
+Result PXIFSR_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifsRHandle, out, archive, path, flags, attributes); }
+Result PXIFSB_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifsBHandle, out, archive, path, flags, attributes); }
+
+Result PXIFS0_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifs0Handle, archive, path); }
+Result PXIFS1_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifs1Handle, archive, path); }
+Result PXIFSR_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifsRHandle, archive, path); }
+Result PXIFSB_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifsBHandle, archive, path); }
+
+Result PXIFS0_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifs0Handle, srcArchive, srcPath, dstArchive, dstPath); }
+Result PXIFS1_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifs1Handle, srcArchive, srcPath, dstArchive, dstPath); }
+Result PXIFSR_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifsRHandle, srcArchive, srcPath, dstArchive, dstPath); }
+Result PXIFSB_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifsBHandle, srcArchive, srcPath, dstArchive, dstPath); }
+
+Result PXIFS0_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifs0Handle, archive, path); }
+Result PXIFS1_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifs1Handle, archive, path); }
+Result PXIFSR_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifsRHandle, archive, path); }
+Result PXIFSB_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifsBHandle, archive, path); }
+
+Result PXIFS0_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifs0Handle, archive, path, attributes, fileSize); }
+Result PXIFS1_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifs1Handle, archive, path, attributes, fileSize); }
+Result PXIFSR_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifsRHandle, archive, path, attributes, fileSize); }
+Result PXIFSB_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifsBHandle, archive, path, attributes, fileSize); }
+
+Result PXIFS0_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifs0Handle, archive, path, attributes); }
+Result PXIFS1_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifs1Handle, archive, path, attributes); }
+Result PXIFSR_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifsRHandle, archive, path, attributes); }
+Result PXIFSB_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifsBHandle, archive, path, attributes); }
+
+Result PXIFS0_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifs0Handle, srcArchive, srcPath, dstArchive, dstPath); }
+Result PXIFS1_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifs1Handle, srcArchive, srcPath, dstArchive, dstPath); }
+Result PXIFSR_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifsRHandle, srcArchive, srcPath, dstArchive, dstPath); }
+Result PXIFSB_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifsBHandle, srcArchive, srcPath, dstArchive, dstPath); }
+
+Result PXIFS0_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifs0Handle, out, archive, path); }
+Result PXIFS1_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifs1Handle, out, archive, path); }
+Result PXIFSR_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifsRHandle, out, archive, path); }
+Result PXIFSB_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifsBHandle, out, archive, path); }
+
+Result PXIFS0_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifs0Handle, file, bytesRead, offset, buffer, size); }
+Result PXIFS1_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifs1Handle, file, bytesRead, offset, buffer, size); }
+Result PXIFSR_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifsRHandle, file, bytesRead, offset, buffer, size); }
+Result PXIFSB_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifsBHandle, file, bytesRead, offset, buffer, size); }
+
+Result PXIFS0_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifs0Handle, file, buffer, size); }
+Result PXIFS1_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifs1Handle, file, buffer, size); }
+Result PXIFSR_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifsRHandle, file, buffer, size); }
+Result PXIFSB_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifsBHandle, file, buffer, size); }
+
+Result PXIFS0_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifs0Handle, file, bytesWritten, offset, buffer, size, flags); }
+Result PXIFS1_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifs1Handle, file, bytesWritten, offset, buffer, size, flags); }
+Result PXIFSR_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifsRHandle, file, bytesWritten, offset, buffer, size, flags); }
+Result PXIFSB_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifsBHandle, file, bytesWritten, offset, buffer, size, flags); }
+
+Result PXIFS0_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifs0Handle, file, inBuffer, inSize, outBuffer, outSize); }
+Result PXIFS1_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifs1Handle, file, inBuffer, inSize, outBuffer, outSize); }
+Result PXIFSR_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifsRHandle, file, inBuffer, inSize, outBuffer, outSize); }
+Result PXIFSB_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifsBHandle, file, inBuffer, inSize, outBuffer, outSize); }
+
+Result PXIFS0_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifs0Handle, file, size); }
+Result PXIFS1_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifs1Handle, file, size); }
+Result PXIFSR_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifsRHandle, file, size); }
+Result PXIFSB_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifsBHandle, file, size); }
+
+Result PXIFS0_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifs0Handle, file, size); }
+Result PXIFS1_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifs1Handle, file, size); }
+Result PXIFSR_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifsRHandle, file, size); }
+Result PXIFSB_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifsBHandle, file, size); }
+
+Result PXIFS0_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifs0Handle, file); }
+Result PXIFS1_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifs1Handle, file); }
+Result PXIFSR_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifsRHandle, file); }
+Result PXIFSB_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifsBHandle, file); }
+
+Result PXIFS0_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifs0Handle, directory, entriesRead, entryCount, entries); }
+Result PXIFS1_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifs1Handle, directory, entriesRead, entryCount, entries); }
+Result PXIFSR_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifsRHandle, directory, entriesRead, entryCount, entries); }
+Result PXIFSB_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifsBHandle, directory, entriesRead, entryCount, entries); }
+
+Result PXIFS0_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifs0Handle, directory); }
+Result PXIFS1_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifs1Handle, directory); }
+Result PXIFSR_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifsRHandle, directory); }
+Result PXIFSB_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifsBHandle, directory); }
+
+Result PXIFS0_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifs0Handle, archive, archiveID, path); }
+Result PXIFS1_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifs1Handle, archive, archiveID, path); }
+Result PXIFSR_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifsRHandle, archive, archiveID, path); }
+Result PXIFSB_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifsBHandle, archive, archiveID, path); }
+
+Result PXIFS0_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifs0Handle, archive, out, path); }
+Result PXIFS1_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifs1Handle, archive, out, path); }
+Result PXIFSR_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifsRHandle, archive, out, path); }
+Result PXIFSB_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifsBHandle, archive, out, path); }
+
+Result PXIFS0_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifs0Handle, archive, out, path); }
+Result PXIFS1_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifs1Handle, archive, out, path); }
+Result PXIFSR_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifsRHandle, archive, out, path); }
+Result PXIFSB_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifsBHandle, archive, out, path); }
+
+Result PXIFS0_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifs0Handle, archive, unknown); }
+Result PXIFS1_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifs1Handle, archive, unknown); }
+Result PXIFSR_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifsRHandle, archive, unknown); }
+Result PXIFSB_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifsBHandle, archive, unknown); }
+
+Result PXIFS0_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifs0Handle, archive); }
+Result PXIFS1_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifs1Handle, archive); }
+Result PXIFSR_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifsRHandle, archive); }
+Result PXIFSB_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifsBHandle, archive); }
+
+Result PXIFS0_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifs0Handle, archive, out); }
+Result PXIFS1_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifs1Handle, archive, out); }
+Result PXIFSR_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifsRHandle, archive, out); }
+Result PXIFSB_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifsBHandle, archive, out); }
+
+Result PXIFS0_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifs0Handle, out); }
+Result PXIFS1_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifs1Handle, out); }
+Result PXIFSR_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifsRHandle, out); }
+Result PXIFSB_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifsBHandle, out); }
+
+Result PXIFS0_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifs0Handle, out); }
+Result PXIFS1_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifs1Handle, out); }
+Result PXIFSR_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifsRHandle, out); }
+Result PXIFSB_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifsBHandle, out); }
+
+Result PXIFS0_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifs0Handle, out); }
+Result PXIFS1_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifs1Handle, out); }
+Result PXIFSR_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifsRHandle, out); }
+Result PXIFSB_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifsBHandle, out); }
+
+Result PXIFS0_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifs0Handle, out); }
+Result PXIFS1_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifs1Handle, out); }
+Result PXIFSR_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifsRHandle, out); }
+Result PXIFSB_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifsBHandle, out); }
+
+Result PXIFS0_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifs0Handle, out); }
+Result PXIFS1_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifs1Handle, out); }
+Result PXIFSR_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifsRHandle, out); }
+Result PXIFSB_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifsBHandle, out); }
+
+Result PXIFS0_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifs0Handle, out); }
+Result PXIFS1_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifs1Handle, out); }
+Result PXIFSR_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifsRHandle, out); }
+Result PXIFSB_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifsBHandle, out); }
+
+Result PXIFS0_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifs0Handle, out, size); }
+Result PXIFS1_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifs1Handle, out, size); }
+Result PXIFSR_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifsRHandle, out, size); }
+Result PXIFSB_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifsBHandle, out, size); }
+
+Result PXIFS0_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifs0Handle, out, size); }
+Result PXIFS1_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifs1Handle, out, size); }
+Result PXIFSR_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifsRHandle, out, size); }
+Result PXIFSB_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifsBHandle, out, size); }
+
+Result PXIFS0_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifs0Handle, out); }
+Result PXIFS1_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifs1Handle, out); }
+Result PXIFSR_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifsRHandle, out); }
+Result PXIFSB_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifsBHandle, out); }
+
+Result PXIFS0_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifs0Handle, out); }
+Result PXIFS1_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifs1Handle, out); }
+Result PXIFSR_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifsRHandle, out); }
+Result PXIFSB_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifsBHandle, out); }
+
+Result PXIFS0_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifs0Handle, out, size); }
+Result PXIFS1_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifs1Handle, out, size); }
+Result PXIFSR_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifsRHandle, out, size); }
+Result PXIFSB_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifsBHandle, out, size); }
+
+Result PXIFS0_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifs0Handle, out, size); }
+Result PXIFS1_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifs1Handle, out, size); }
+Result PXIFSR_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifsRHandle, out, size); }
+Result PXIFSB_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifsBHandle, out, size); }
+
+Result PXIFS0_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifs0Handle); }
+Result PXIFS1_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifs1Handle); }
+Result PXIFSR_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifsRHandle); }
+Result PXIFSB_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifsBHandle); }
+
+Result PXIFS0_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifs0Handle); }
+Result PXIFS1_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifs1Handle); }
+Result PXIFSR_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifsRHandle); }
+Result PXIFSB_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifsBHandle); }
+
+Result PXIFS0_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifs0Handle, inserted); }
+Result PXIFS1_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifs1Handle, inserted); }
+Result PXIFSR_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifsRHandle, inserted); }
+Result PXIFSB_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifsBHandle, inserted); }
+
+Result PXIFS0_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifs0Handle, status); }
+Result PXIFS1_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifs1Handle, status); }
+Result PXIFSR_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifsRHandle, status); }
+Result PXIFSB_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifsBHandle, status); }
+
+Result PXIFS0_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifs0Handle, status); }
+Result PXIFS1_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifs1Handle, status); }
+Result PXIFSR_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifsRHandle, status); }
+Result PXIFSB_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifsBHandle, status); }
+
+Result PXIFS0_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifs0Handle, status); }
+Result PXIFS1_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifs1Handle, status); }
+Result PXIFSR_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifsRHandle, status); }
+Result PXIFSB_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifsBHandle, status); }
+
+Result PXIFS0_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifs0Handle, commandId); }
+Result PXIFS1_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifs1Handle, commandId); }
+Result PXIFSR_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifsRHandle, commandId); }
+Result PXIFSB_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifsBHandle, commandId); }
+
+Result PXIFS0_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifs0Handle, commandId, address); }
+Result PXIFS1_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifs1Handle, commandId, address); }
+Result PXIFSR_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifsRHandle, commandId, address); }
+Result PXIFSB_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifsBHandle, commandId, address); }
+
+Result PXIFS0_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifs0Handle, commandId, size, output); }
+Result PXIFS1_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifs1Handle, commandId, size, output); }
+Result PXIFSR_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifsRHandle, commandId, size, output); }
+Result PXIFSB_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifsBHandle, commandId, size, output); }
+
+Result PXIFS0_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifs0Handle, commandId, address, size, output); }
+Result PXIFS1_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifs1Handle, commandId, address, size, output); }
+Result PXIFSR_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifsRHandle, commandId, address, size, output); }
+Result PXIFSB_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifsBHandle, commandId, address, size, output); }
+
+Result PXIFS0_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifs0Handle, commandId, size, input); }
+Result PXIFS1_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifs1Handle, commandId, size, input); }
+Result PXIFSR_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifsRHandle, commandId, size, input); }
+Result PXIFSB_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifsBHandle, commandId, size, input); }
+
+Result PXIFS0_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifs0Handle, commandId, address, size, input); }
+Result PXIFS1_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifs1Handle, commandId, address, size, input); }
+Result PXIFSR_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifsRHandle, commandId, address, size, input); }
+Result PXIFSB_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifsBHandle, commandId, address, size, input); }
+
+Result PXIFS0_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifs0Handle, commandId, address, size, output); }
+Result PXIFS1_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifs1Handle, commandId, address, size, output); }
+Result PXIFSR_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifsRHandle, commandId, address, size, output); }
+Result PXIFSB_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifsBHandle, commandId, address, size, output); }
+
+Result PXIFS0_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifs0Handle, address, size, input); }
+Result PXIFS1_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifs1Handle, address, size, input); }
+Result PXIFSR_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifsRHandle, address, size, input); }
+Result PXIFSB_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifsBHandle, address, size, input); }
+
+Result PXIFS0_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifs0Handle, address); }
+Result PXIFS1_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifs1Handle, address); }
+Result PXIFSR_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifsRHandle, address); }
+Result PXIFSB_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifsBHandle, address); }
+
+Result PXIFS0_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifs0Handle, info, archive); }
+Result PXIFS1_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifs1Handle, info, archive); }
+Result PXIFSR_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifsRHandle, info, archive); }
+Result PXIFSB_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifsBHandle, info, archive); }
+
+Result PXIFS0_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifs0Handle, baudRate); }
+Result PXIFS1_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifs1Handle, baudRate); }
+Result PXIFSR_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifsRHandle, baudRate); }
+Result PXIFSB_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifsBHandle, baudRate); }
+
+Result PXIFS0_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifs0Handle, busMode); }
+Result PXIFS1_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifs1Handle, busMode); }
+Result PXIFSR_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifsRHandle, busMode); }
+Result PXIFSB_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifsBHandle, busMode); }
+
+Result PXIFS0_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifs0Handle, unk); }
+Result PXIFS1_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifs1Handle, unk); }
+Result PXIFSR_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifsRHandle, unk); }
+Result PXIFSB_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifsBHandle, unk); }
+
+Result PXIFS0_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifs0Handle, info); }
+Result PXIFS1_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifs1Handle, info); }
+Result PXIFSR_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifsRHandle, info); }
+Result PXIFSB_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifsBHandle, info); }
+
+Result PXIFS0_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifs0Handle, info); }
+Result PXIFS1_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifs1Handle, info); }
+Result PXIFSR_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifsRHandle, info); }
+Result PXIFSB_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifsBHandle, info); }
+
+Result PXIFS0_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifs0Handle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
+Result PXIFS1_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifs1Handle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
+Result PXIFSR_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifsRHandle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
+Result PXIFSB_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifsBHandle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
+
+Result PXIFS0_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifs0Handle, index, mediaType, programId, type); }
+Result PXIFS1_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifs1Handle, index, mediaType, programId, type); }
+Result PXIFSR_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifsRHandle, index, mediaType, programId, type); }
+Result PXIFSB_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifsBHandle, index, mediaType, programId, type); }
+
+Result PXIFS0_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifs0Handle, mediaType, programId, header); }
+Result PXIFS1_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifs1Handle, mediaType, programId, header); }
+Result PXIFSR_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifsRHandle, mediaType, programId, header); }
+Result PXIFSB_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifsBHandle, mediaType, programId, header); }
+
+Result PXIFS0_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifs0Handle, mediaType, programId, banner, unk); }
+Result PXIFS1_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifs1Handle, mediaType, programId, banner, unk); }
+Result PXIFSR_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifsRHandle, mediaType, programId, banner, unk); }
+Result PXIFSB_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifsBHandle, mediaType, programId, banner, unk); }
+
+Result PXIFS0_0x3D(u32 unk) { return FSPXI_0x3D(pxifs0Handle, unk); }
+Result PXIFS1_0x3D(u32 unk) { return FSPXI_0x3D(pxifs1Handle, unk); }
+Result PXIFSR_0x3D(u32 unk) { return FSPXI_0x3D(pxifsRHandle, unk); }
+Result PXIFSB_0x3D(u32 unk) { return FSPXI_0x3D(pxifsBHandle, unk); }
+
+Result PXIFS0_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifs0Handle); }
+Result PXIFS1_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifs1Handle); }
+Result PXIFSR_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifsRHandle); }
+Result PXIFSB_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifsBHandle); }
+
+Result PXIFS0_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifs0Handle); }
+Result PXIFS1_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifs1Handle); }
+Result PXIFSR_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifsRHandle); }
+Result PXIFSB_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifsBHandle); }
+
+Result PXIFS0_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifs0Handle); }
+Result PXIFS1_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifs1Handle); }
+Result PXIFSR_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifsRHandle); }
+Result PXIFSB_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifsBHandle); }
+
+Result PXIFS0_CreateSeed(void) { return FSPXI_CreateSeed(pxifs0Handle); }
+Result PXIFS1_CreateSeed(void) { return FSPXI_CreateSeed(pxifs1Handle); }
+Result PXIFSR_CreateSeed(void) { return FSPXI_CreateSeed(pxifsRHandle); }
+Result PXIFSB_CreateSeed(void) { return FSPXI_CreateSeed(pxifsBHandle); }
+
+Result PXIFS0_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifs0Handle, out, length); }
+Result PXIFS1_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifs1Handle, out, length); }
+Result PXIFSR_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifsRHandle, out, length); }
+Result PXIFSB_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifsBHandle, out, length); }
+
+Result PXIFS0_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifs0Handle, archiveResource, mediaType); }
+Result PXIFS1_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifs1Handle, archiveResource, mediaType); }
+Result PXIFSR_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifsRHandle, archiveResource, mediaType); }
+Result PXIFSB_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifsBHandle, archiveResource, mediaType); }
+
+Result PXIFS0_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifs0Handle, seed); }
+Result PXIFS1_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifs1Handle, seed); }
+Result PXIFSR_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifsRHandle, seed); }
+Result PXIFSB_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifsBHandle, seed); }
+
+Result PXIFS0_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifs0Handle, seed); }
+Result PXIFS1_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifs1Handle, seed); }
+Result PXIFSR_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifsRHandle, seed); }
+Result PXIFSB_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifsBHandle, seed); }
+
+Result PXIFS0_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifs0Handle, bannerSize, mediaType, programId, banner); }
+Result PXIFS1_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifs1Handle, bannerSize, mediaType, programId, banner); }
+Result PXIFSR_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifsRHandle, bannerSize, mediaType, programId, banner); }
+Result PXIFSB_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifsBHandle, bannerSize, mediaType, programId, banner); }
+
+Result PXIFS0_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifs0Handle, buf, size); }
+Result PXIFS1_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifs1Handle, buf, size); }
+Result PXIFSR_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifsRHandle, buf, size); }
+Result PXIFSB_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifsBHandle, buf, size); }
+
+Result PXIFS0_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifs0Handle, archive, out, path, size); }
+Result PXIFS1_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifs1Handle, archive, out, path, size); }
+Result PXIFSR_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifsRHandle, archive, out, path, size); }
+Result PXIFSB_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifsBHandle, archive, out, path, size); }
+
+Result PXIFS0_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifs0Handle, bytesRead, fileOffset, size, data); }
+Result PXIFS1_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifs1Handle, bytesRead, fileOffset, size, data); }
+Result PXIFSR_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifsRHandle, bytesRead, fileOffset, size, data); }
+Result PXIFSB_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifsBHandle, bytesRead, fileOffset, size, data); }
+
+Result PXIFS0_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifs0Handle, fileSize); }
+Result PXIFS1_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifs1Handle, fileSize); }
+Result PXIFSR_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifsRHandle, fileSize); }
+Result PXIFSB_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifsBHandle, fileSize); }
+
+Result PXIFS0_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifs0Handle, context); }
+Result PXIFS1_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifs1Handle, context); }
+Result PXIFSR_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifsRHandle, context); }
+Result PXIFSB_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifsBHandle, context); }
+
+Result PXIFS0_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifs0Handle, context, clear); }
+Result PXIFS1_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifs1Handle, context, clear); }
+Result PXIFSR_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifsRHandle, context, clear); }
+Result PXIFSB_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifsBHandle, context, clear); }
+
+Result PXIFS0_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifs0Handle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
+Result PXIFS1_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifs1Handle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
+Result PXIFSR_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifsRHandle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
+Result PXIFSB_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifsBHandle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
+
+Result PXIFS0_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifs0Handle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
+Result PXIFS1_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifs1Handle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
+Result PXIFSR_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifsRHandle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
+Result PXIFSB_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifsBHandle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
+
+Result PXIFS0_0x4F(u64 unk) { return FSPXI_0x4F(pxifs0Handle, unk); }
+Result PXIFS1_0x4F(u64 unk) { return FSPXI_0x4F(pxifs1Handle, unk); }
+Result PXIFSR_0x4F(u64 unk) { return FSPXI_0x4F(pxifsRHandle, unk); }
+Result PXIFSB_0x4F(u64 unk) { return FSPXI_0x4F(pxifsBHandle, unk); }
+
+Result PXIFS0_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifs0Handle, priority); }
+Result PXIFS1_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifs1Handle, priority); }
+Result PXIFSR_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifsRHandle, priority); }
+Result PXIFSB_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifsBHandle, priority); }
+
+Result PXIFS0_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifs0Handle, enable); }
+Result PXIFS1_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifs1Handle, enable); }
+Result PXIFSR_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifsRHandle, enable); }
+Result PXIFSB_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifsBHandle, enable); }
+
+Result PXIFS0_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifs0Handle, idsWritten, idsSize, ids); }
+Result PXIFS1_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifs1Handle, idsWritten, idsSize, ids); }
+Result PXIFSR_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifsRHandle, idsWritten, idsSize, ids); }
+Result PXIFSB_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifsBHandle, idsWritten, idsSize, ids); }
+
+Result PXIFS0_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifs0Handle, buffer, size, unk); }
+Result PXIFS1_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifs1Handle, buffer, size, unk); }
+Result PXIFSR_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifsRHandle, buffer, size, unk); }
+Result PXIFSB_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifsBHandle, buffer, size, unk); }
+
+Result PXIFS0_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifs0Handle, out, archive, path); }
+Result PXIFS1_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifs1Handle, out, archive, path); }
+Result PXIFSR_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifsRHandle, out, archive, path); }
+Result PXIFSB_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifsBHandle, out, archive, path); }

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -7,107 +7,7 @@
 #include <3ds/synchronization.h>
 #include <3ds/types.h>
 
-static Handle pxifs0Handle;
-static int pxifs0RefCount;
-
-static Handle pxifs1Handle;
-static int pxifs1RefCount;
-
-static Handle pxifsRHandle;
-static int pxifsRRefCount;
-
-static Handle pxifsBHandle;
-static int pxifsBRefCount;
-
-Result pxifs0Init(Handle servhandle)
-{
-     Result res=0;
-     if (AtomicPostIncrement(&pxifs0RefCount)) return 0;
-     if (servhandle)
-     {
-         pxifs0Handle = servhandle;
-     }
-     else
-     {
-         res = srvGetServiceHandle(&pxifs0Handle, "PxiFS0");
-         if (R_FAILED(res)) AtomicDecrement(&pxifs0RefCount);
-     }
-     return res;
-}
-
-Result pxifs1Init(Handle servhandle)
-{
-     Result res=0;
-     if (AtomicPostIncrement(&pxifs1RefCount)) return 0;
-     if (servhandle)
-     {
-         pxifs1Handle = servhandle;
-     }
-     else
-     {
-         res = srvGetServiceHandle(&pxifs1Handle, "PxiFS1");
-         if (R_FAILED(res)) AtomicDecrement(&pxifs1RefCount);
-     }
-     return res;
-}
-
-Result pxifsRInit(Handle servhandle)
-{
-     Result res=0;
-     if (AtomicPostIncrement(&pxifsRRefCount)) return 0;
-     if (servhandle)
-     {
-         pxifsRHandle = servhandle;
-     }
-     else
-     {
-         res = srvGetServiceHandle(&pxifsRHandle, "PxiFSR");
-         if (R_FAILED(res)) AtomicDecrement(&pxifsRRefCount);
-     }
-     return res;
-}
-
-Result pxifsBInit(Handle servhandle)
-{
-     Result res=0;
-     if (AtomicPostIncrement(&pxifsBRefCount)) return 0;
-     if (servhandle)
-     {
-         pxifsBHandle = servhandle;
-     }
-     else
-     {
-         res = srvGetServiceHandle(&pxifsBHandle, "PxiFSB");
-         if (R_FAILED(res)) AtomicDecrement(&pxifsBRefCount);
-     }
-     return res;
-}
-
-void pxifs0Exit(void)
-{
-    if (AtomicDecrement(&pxifs0RefCount)) return;
-    svcCloseHandle(pxifs0Handle);
-}
-
-void pxifs1Exit(void)
-{
-    if (AtomicDecrement(&pxifs1RefCount)) return;
-    svcCloseHandle(pxifs1Handle);
-}
-
-void pxifsRExit(void)
-{
-    if (AtomicDecrement(&pxifsRRefCount)) return;
-    svcCloseHandle(pxifsRHandle);
-}
-
-void pxifsBExit(void)
-{
-    if (AtomicDecrement(&pxifsBRefCount)) return;
-    svcCloseHandle(pxifsBHandle);
-}
-
-static Result FSPXI_OpenFile(Handle serviceHandle, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes)
+Result FSPXI_OpenFile(Handle serviceHandle, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -130,7 +30,7 @@ static Result FSPXI_OpenFile(Handle serviceHandle, FSPXI_File* out, FSPXI_Archiv
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_DeleteFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
+Result FSPXI_DeleteFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -149,7 +49,7 @@ static Result FSPXI_DeleteFile(Handle serviceHandle, FSPXI_Archive archive, FS_P
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_RenameFile(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
+Result FSPXI_RenameFile(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -174,7 +74,7 @@ static Result FSPXI_RenameFile(Handle serviceHandle, FSPXI_Archive srcArchive, F
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_DeleteDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
+Result FSPXI_DeleteDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -193,7 +93,7 @@ static Result FSPXI_DeleteDirectory(Handle serviceHandle, FSPXI_Archive archive,
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize)
+Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -215,7 +115,7 @@ static Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_P
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CreateDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes)
+Result FSPXI_CreateDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -235,7 +135,7 @@ static Result FSPXI_CreateDirectory(Handle serviceHandle, FSPXI_Archive archive,
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_RenameDirectory(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
+Result FSPXI_RenameDirectory(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -260,7 +160,7 @@ static Result FSPXI_RenameDirectory(Handle serviceHandle, FSPXI_Archive srcArchi
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_OpenDirectory(Handle serviceHandle, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path)
+Result FSPXI_OpenDirectory(Handle serviceHandle, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -281,7 +181,7 @@ static Result FSPXI_OpenDirectory(Handle serviceHandle, FSPXI_Directory* out, FS
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size)
+Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -302,7 +202,7 @@ static Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRe
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, u32* buffer, u32 size)
+Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, u32* buffer, u32 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -319,7 +219,7 @@ static Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File fil
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags)
+Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -341,7 +241,7 @@ static Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesW
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CalcSavegameMAC(Handle serviceHandle, FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize)
+Result FSPXI_CalcSavegameMAC(Handle serviceHandle, FSPXI_File file, const void* inBuffer, u32 inSize, void* outBuffer, u32 outSize)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -361,7 +261,7 @@ static Result FSPXI_CalcSavegameMAC(Handle serviceHandle, FSPXI_File file, void*
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetFileSize(Handle serviceHandle, FSPXI_File file, u64* size)
+Result FSPXI_GetFileSize(Handle serviceHandle, FSPXI_File file, u64* size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -377,7 +277,7 @@ static Result FSPXI_GetFileSize(Handle serviceHandle, FSPXI_File file, u64* size
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_SetFileSize(Handle serviceHandle, FSPXI_File file, u64 size)
+Result FSPXI_SetFileSize(Handle serviceHandle, FSPXI_File file, u64 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -393,7 +293,7 @@ static Result FSPXI_SetFileSize(Handle serviceHandle, FSPXI_File file, u64 size)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CloseFile(Handle serviceHandle, FSPXI_File file)
+Result FSPXI_CloseFile(Handle serviceHandle, FSPXI_File file)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -407,7 +307,7 @@ static Result FSPXI_CloseFile(Handle serviceHandle, FSPXI_File file)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ReadDirectory(Handle serviceHandle, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries)
+Result FSPXI_ReadDirectory(Handle serviceHandle, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -426,7 +326,7 @@ static Result FSPXI_ReadDirectory(Handle serviceHandle, FSPXI_Directory director
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directory)
+Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directory)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -440,7 +340,7 @@ static Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directo
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path)
+Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path)
 {
     if (!archive) return -2;
 
@@ -461,7 +361,7 @@ static Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, FS_Path path)
+Result FSPXI_Unknown0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -481,7 +381,7 @@ static Result FSPXI_0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, F
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, FS_Path path)
+Result FSPXI_Unknown0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -501,7 +401,7 @@ static Result FSPXI_0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, 
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CommitSaveData(Handle serviceHandle, FSPXI_Archive archive, u32 id)
+Result FSPXI_CommitSaveData(Handle serviceHandle, FSPXI_Archive archive, u32 id)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -516,7 +416,7 @@ static Result FSPXI_CommitSaveData(Handle serviceHandle, FSPXI_Archive archive, 
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CloseArchive(Handle serviceHandle, FSPXI_Archive archive)
+Result FSPXI_CloseArchive(Handle serviceHandle, FSPXI_Archive archive)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -530,7 +430,7 @@ static Result FSPXI_CloseArchive(Handle serviceHandle, FSPXI_Archive archive)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x17(Handle serviceHandle, FSPXI_Archive archive, bool* out)
+Result FSPXI_Unknown0x17(Handle serviceHandle, FSPXI_Archive archive, bool* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -546,7 +446,7 @@ static Result FSPXI_0x17(Handle serviceHandle, FSPXI_Archive archive, bool* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetCardType(Handle serviceHandle, FS_CardType* out)
+Result FSPXI_GetCardType(Handle serviceHandle, FS_CardType* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -560,7 +460,7 @@ static Result FSPXI_GetCardType(Handle serviceHandle, FS_CardType* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSdmcArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
+Result FSPXI_GetSdmcArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -580,7 +480,7 @@ static Result FSPXI_GetSdmcArchiveResource(Handle serviceHandle, FS_ArchiveResou
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetNandArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
+Result FSPXI_GetNandArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -600,7 +500,7 @@ static Result FSPXI_GetNandArchiveResource(Handle serviceHandle, FS_ArchiveResou
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSdmcFatFsError(Handle serviceHandle, u32* out)
+Result FSPXI_GetSdmcFatFsError(Handle serviceHandle, u32* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -614,7 +514,7 @@ static Result FSPXI_GetSdmcFatFsError(Handle serviceHandle, u32* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_IsSdmcDetected(Handle serviceHandle, bool* out)
+Result FSPXI_IsSdmcDetected(Handle serviceHandle, bool* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -628,7 +528,7 @@ static Result FSPXI_IsSdmcDetected(Handle serviceHandle, bool* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_IsSdmcWritable(Handle serviceHandle, bool* out)
+Result FSPXI_IsSdmcWritable(Handle serviceHandle, bool* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -642,7 +542,7 @@ static Result FSPXI_IsSdmcWritable(Handle serviceHandle, bool* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSdmcCid(Handle serviceHandle, void* out, u32 size)
+Result FSPXI_GetSdmcCid(Handle serviceHandle, void* out, u32 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -657,7 +557,7 @@ static Result FSPXI_GetSdmcCid(Handle serviceHandle, void* out, u32 size)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetNandCid(Handle serviceHandle, void* out, u32 size)
+Result FSPXI_GetNandCid(Handle serviceHandle, void* out, u32 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -672,7 +572,7 @@ static Result FSPXI_GetNandCid(Handle serviceHandle, void* out, u32 size)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSdmcSpeedInfo(Handle serviceHandle, u32* out)
+Result FSPXI_GetSdmcSpeedInfo(Handle serviceHandle, u32* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -686,7 +586,7 @@ static Result FSPXI_GetSdmcSpeedInfo(Handle serviceHandle, u32* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetNandSpeedInfo(Handle serviceHandle, u32* out)
+Result FSPXI_GetNandSpeedInfo(Handle serviceHandle, u32* out)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -700,7 +600,7 @@ static Result FSPXI_GetNandSpeedInfo(Handle serviceHandle, u32* out)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSdmcLog(Handle serviceHandle, void* out, u32 size)
+Result FSPXI_GetSdmcLog(Handle serviceHandle, void* out, u32 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -715,7 +615,7 @@ static Result FSPXI_GetSdmcLog(Handle serviceHandle, void* out, u32 size)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetNandLog(Handle serviceHandle, void* out, u32 size)
+Result FSPXI_GetNandLog(Handle serviceHandle, void* out, u32 size)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -730,7 +630,7 @@ static Result FSPXI_GetNandLog(Handle serviceHandle, void* out, u32 size)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ClearSdmcLog(Handle serviceHandle)
+Result FSPXI_ClearSdmcLog(Handle serviceHandle)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -742,7 +642,7 @@ static Result FSPXI_ClearSdmcLog(Handle serviceHandle)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ClearNandLog(Handle serviceHandle)
+Result FSPXI_ClearNandLog(Handle serviceHandle)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -754,7 +654,7 @@ static Result FSPXI_ClearNandLog(Handle serviceHandle)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardSlotIsInserted(Handle serviceHandle, bool* inserted)
+Result FSPXI_CardSlotIsInserted(Handle serviceHandle, bool* inserted)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -768,7 +668,7 @@ static Result FSPXI_CardSlotIsInserted(Handle serviceHandle, bool* inserted)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardSlotPowerOn(Handle serviceHandle, bool* status)
+Result FSPXI_CardSlotPowerOn(Handle serviceHandle, bool* status)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -782,7 +682,7 @@ static Result FSPXI_CardSlotPowerOn(Handle serviceHandle, bool* status)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardSlotPowerOff(Handle serviceHandle, bool* status)
+Result FSPXI_CardSlotPowerOff(Handle serviceHandle, bool* status)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -796,7 +696,7 @@ static Result FSPXI_CardSlotPowerOff(Handle serviceHandle, bool* status)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardSlotGetCardIFPowerStatus(Handle serviceHandle, bool* status)
+Result FSPXI_CardSlotGetCardIFPowerStatus(Handle serviceHandle, bool* status)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -810,7 +710,7 @@ static Result FSPXI_CardSlotGetCardIFPowerStatus(Handle serviceHandle, bool* sta
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectCommand(Handle serviceHandle, u8 commandId)
+Result FSPXI_CardNorDirectCommand(Handle serviceHandle, u8 commandId)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -823,7 +723,7 @@ static Result FSPXI_CardNorDirectCommand(Handle serviceHandle, u8 commandId)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectCommandWithAddress(Handle serviceHandle, u8 commandId, u32 address)
+Result FSPXI_CardNorDirectCommandWithAddress(Handle serviceHandle, u8 commandId, u32 address)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -837,7 +737,7 @@ static Result FSPXI_CardNorDirectCommandWithAddress(Handle serviceHandle, u8 com
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectRead(Handle serviceHandle, u8 commandId, u32 size, u8* output)
+Result FSPXI_CardNorDirectRead(Handle serviceHandle, u8 commandId, u32 size, void* output)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -853,7 +753,7 @@ static Result FSPXI_CardNorDirectRead(Handle serviceHandle, u8 commandId, u32 si
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectReadWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, u8* output)
+Result FSPXI_CardNorDirectReadWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, void* output)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -870,7 +770,7 @@ static Result FSPXI_CardNorDirectReadWithAddress(Handle serviceHandle, u8 comman
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectWrite(Handle serviceHandle, u8 commandId, u32 size, u8* input)
+Result FSPXI_CardNorDirectWrite(Handle serviceHandle, u8 commandId, u32 size, const void* input)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -886,7 +786,7 @@ static Result FSPXI_CardNorDirectWrite(Handle serviceHandle, u8 commandId, u32 s
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectWriteWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, u8* input)
+Result FSPXI_CardNorDirectWriteWithAddress(Handle serviceHandle, u8 commandId, u32 address, u32 size, const void* input)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -903,7 +803,7 @@ static Result FSPXI_CardNorDirectWriteWithAddress(Handle serviceHandle, u8 comma
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectRead_4xIO(Handle serviceHandle, u8 commandId, u32 address, u32 size, u8* output)
+Result FSPXI_CardNorDirectRead_4xIO(Handle serviceHandle, u8 commandId, u32 address, u32 size, void* output)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -920,7 +820,7 @@ static Result FSPXI_CardNorDirectRead_4xIO(Handle serviceHandle, u8 commandId, u
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectCpuWriteWithoutVerify(Handle serviceHandle, u32 address, u32 size, u8* input)
+Result FSPXI_CardNorDirectCpuWriteWithoutVerify(Handle serviceHandle, u32 address, u32 size, const void* input)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -936,7 +836,7 @@ static Result FSPXI_CardNorDirectCpuWriteWithoutVerify(Handle serviceHandle, u32
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CardNorDirectSectorEraseWithoutVerify(Handle serviceHandle, u32 address)
+Result FSPXI_CardNorDirectSectorEraseWithoutVerify(Handle serviceHandle, u32 address)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -949,7 +849,7 @@ static Result FSPXI_CardNorDirectSectorEraseWithoutVerify(Handle serviceHandle, 
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, FSPXI_Archive archive)
+Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, FSPXI_Archive archive)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -965,7 +865,7 @@ static Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, F
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_SetCardSpiBaudrate(Handle serviceHandle, FS_CardSpiBaudRate baudRate)
+Result FSPXI_SetCardSpiBaudrate(Handle serviceHandle, FS_CardSpiBaudRate baudRate)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -978,7 +878,7 @@ static Result FSPXI_SetCardSpiBaudrate(Handle serviceHandle, FS_CardSpiBaudRate 
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_SetCardSpiBusMode(Handle serviceHandle, FS_CardSpiBusMode busMode)
+Result FSPXI_SetCardSpiBusMode(Handle serviceHandle, FS_CardSpiBusMode busMode)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -991,7 +891,7 @@ static Result FSPXI_SetCardSpiBusMode(Handle serviceHandle, FS_CardSpiBusMode bu
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_SendInitializeInfoTo9(Handle serviceHandle, u8 unk)
+Result FSPXI_SendInitializeInfoTo9(Handle serviceHandle, u8 unk)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1004,7 +904,7 @@ static Result FSPXI_SendInitializeInfoTo9(Handle serviceHandle, u8 unk)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CreateExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
+Result FSPXI_CreateExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -1017,7 +917,7 @@ static Result FSPXI_CreateExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo i
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_DeleteExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
+Result FSPXI_DeleteExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -1030,7 +930,7 @@ static Result FSPXI_DeleteExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo i
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids)
+Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -1050,7 +950,7 @@ static Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, 
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type)
+Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1068,7 +968,7 @@ static Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* header)
+Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* header)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1085,7 +985,7 @@ static Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaT
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* banner, u8 unk)
+Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, u8* banner, u8 unk)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1103,7 +1003,7 @@ static Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType media
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x3D(Handle serviceHandle, u32 unk)
+Result FSPXI_Unknown0x3D(Handle serviceHandle, u32 unk)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1116,7 +1016,7 @@ static Result FSPXI_0x3D(Handle serviceHandle, u32 unk)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_DeleteSdmcRoot(Handle serviceHandle)
+Result FSPXI_DeleteSdmcRoot(Handle serviceHandle)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1128,7 +1028,7 @@ static Result FSPXI_DeleteSdmcRoot(Handle serviceHandle)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle)
+Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1141,7 +1041,7 @@ static Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle)
+Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1153,7 +1053,7 @@ static Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_CreateSeed(Handle serviceHandle)
+Result FSPXI_CreateSeed(Handle serviceHandle)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1165,7 +1065,7 @@ static Result FSPXI_CreateSeed(Handle serviceHandle)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u8* out, u32 length)
+Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u16* out, u32 length)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1180,7 +1080,7 @@ static Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u8* out, u32 length
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetArchiveResource(Handle serviceHandle, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType)
+Result FSPXI_GetArchiveResource(Handle serviceHandle, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1195,7 +1095,7 @@ static Result FSPXI_GetArchiveResource(Handle serviceHandle, FS_ArchiveResource*
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed)
+Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1209,7 +1109,7 @@ static Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_Int
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed)
+Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_IntegrityVerificationSeed* seed)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1223,7 +1123,7 @@ static Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, FS_Int
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner)
+Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1241,7 +1141,7 @@ static Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize,
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x47(Handle serviceHandle, void* buf, u32 size)
+Result FSPXI_Unknown0x47(Handle serviceHandle, void* buf, u32 size)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1256,7 +1156,7 @@ static Result FSPXI_0x47(Handle serviceHandle, void* buf, u32 size)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u64* out, u16* path, u32 size)
+Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u64* out, const u16* path, u32 size)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1275,7 +1175,7 @@ static Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive arch
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, u8* data)
+Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, u8* data)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1295,7 +1195,7 @@ static Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fi
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_GetSpecialFileSize(Handle serviceHandle, u64* fileSize)
+Result FSPXI_GetSpecialFileSize(Handle serviceHandle, u64* fileSize)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1310,7 +1210,7 @@ static Result FSPXI_GetSpecialFileSize(Handle serviceHandle, u64* fileSize)
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_StartDeviceMoveAsSource(Handle serviceHandle, FS_DeviceMoveContext* context)
+Result FSPXI_StartDeviceMoveAsSource(Handle serviceHandle, FS_DeviceMoveContext* context)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1324,7 +1224,7 @@ static Result FSPXI_StartDeviceMoveAsSource(Handle serviceHandle, FS_DeviceMoveC
     return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_DeviceMoveContext context, bool clear)
+Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_DeviceMoveContext context, bool clear)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1338,7 +1238,7 @@ static Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_Device
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk)
+Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1351,7 +1251,7 @@ static Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* b
     cmdbuf[5] = readBufferSize;
     cmdbuf[6] = unk;
     cmdbuf[7] = hashtableSize;
-    cmdbuf[8] = IPC_Desc_PXIBuffer(hashtableSize, 0, true);
+    cmdbuf[8] = IPC_Desc_PXIBuffer(hashtableSize, 0, false);
     cmdbuf[9] = (u32) hashtable;
     cmdbuf[10] = IPC_Desc_PXIBuffer(readBufferSize, 1, false);
     cmdbuf[11] = (u32) readBuffer;
@@ -1363,7 +1263,7 @@ static Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* b
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2)
+Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1389,7 +1289,7 @@ static Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* 
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x4F(Handle serviceHandle, u64 unk)
+Result FSPXI_Unknown0x4F(Handle serviceHandle, u64 unk)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1403,7 +1303,7 @@ static Result FSPXI_0x4F(Handle serviceHandle, u64 unk)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_SetPriority(Handle serviceHandle, u32 priority)
+Result FSPXI_SetPriority(Handle serviceHandle, u32 priority)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1416,7 +1316,7 @@ static Result FSPXI_SetPriority(Handle serviceHandle, u32 priority)
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enable)
+Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enable)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1429,7 +1329,7 @@ static Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enab
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_EnumerateSystemSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, u32* ids)
+Result FSPXI_EnumerateSystemSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, u32* ids)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1446,7 +1346,7 @@ static Result FSPXI_EnumerateSystemSaveData(Handle serviceHandle, u32* idsWritte
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 unk)
+Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 unk)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1462,7 +1362,7 @@ static Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size,
 	return (Result) cmdbuf[1];
 }
 
-static Result FSPXI_0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive, FS_Path path)
+Result FSPXI_Unknown0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive, FS_Path path)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1484,423 +1384,3 @@ static Result FSPXI_0x56(Handle serviceHandle, u32 (*out)[4], FS_Archive archive
 
     return (Result) cmdbuf[1];
 }
-
-Result PXIFS0_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifs0Handle, out, archive, path, flags, attributes); }
-Result PXIFS1_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifs1Handle, out, archive, path, flags, attributes); }
-Result PXIFSR_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifsRHandle, out, archive, path, flags, attributes); }
-Result PXIFSB_OpenFile(FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes) { return FSPXI_OpenFile(pxifsBHandle, out, archive, path, flags, attributes); }
-
-Result PXIFS0_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifs0Handle, archive, path); }
-Result PXIFS1_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifs1Handle, archive, path); }
-Result PXIFSR_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifsRHandle, archive, path); }
-Result PXIFSB_DeleteFile(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteFile(pxifsBHandle, archive, path); }
-
-Result PXIFS0_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifs0Handle, srcArchive, srcPath, dstArchive, dstPath); }
-Result PXIFS1_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifs1Handle, srcArchive, srcPath, dstArchive, dstPath); }
-Result PXIFSR_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifsRHandle, srcArchive, srcPath, dstArchive, dstPath); }
-Result PXIFSB_RenameFile(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameFile(pxifsBHandle, srcArchive, srcPath, dstArchive, dstPath); }
-
-Result PXIFS0_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifs0Handle, archive, path); }
-Result PXIFS1_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifs1Handle, archive, path); }
-Result PXIFSR_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifsRHandle, archive, path); }
-Result PXIFSB_DeleteDirectory(FSPXI_Archive archive, FS_Path path) { return FSPXI_DeleteDirectory(pxifsBHandle, archive, path); }
-
-Result PXIFS0_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifs0Handle, archive, path, attributes, fileSize); }
-Result PXIFS1_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifs1Handle, archive, path, attributes, fileSize); }
-Result PXIFSR_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifsRHandle, archive, path, attributes, fileSize); }
-Result PXIFSB_CreateFile(FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize) { return FSPXI_CreateFile(pxifsBHandle, archive, path, attributes, fileSize); }
-
-Result PXIFS0_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifs0Handle, archive, path, attributes); }
-Result PXIFS1_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifs1Handle, archive, path, attributes); }
-Result PXIFSR_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifsRHandle, archive, path, attributes); }
-Result PXIFSB_CreateDirectory(FSPXI_Archive archive, FS_Path path, u32 attributes) { return FSPXI_CreateDirectory(pxifsBHandle, archive, path, attributes); }
-
-Result PXIFS0_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifs0Handle, srcArchive, srcPath, dstArchive, dstPath); }
-Result PXIFS1_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifs1Handle, srcArchive, srcPath, dstArchive, dstPath); }
-Result PXIFSR_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifsRHandle, srcArchive, srcPath, dstArchive, dstPath); }
-Result PXIFSB_RenameDirectory(FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath) { return FSPXI_RenameDirectory(pxifsBHandle, srcArchive, srcPath, dstArchive, dstPath); }
-
-Result PXIFS0_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifs0Handle, out, archive, path); }
-Result PXIFS1_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifs1Handle, out, archive, path); }
-Result PXIFSR_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifsRHandle, out, archive, path); }
-Result PXIFSB_OpenDirectory(FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path) { return FSPXI_OpenDirectory(pxifsBHandle, out, archive, path); }
-
-Result PXIFS0_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifs0Handle, file, bytesRead, offset, buffer, size); }
-Result PXIFS1_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifs1Handle, file, bytesRead, offset, buffer, size); }
-Result PXIFSR_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifsRHandle, file, bytesRead, offset, buffer, size); }
-Result PXIFSB_ReadFile(FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size) { return FSPXI_ReadFile(pxifsBHandle, file, bytesRead, offset, buffer, size); }
-
-Result PXIFS0_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifs0Handle, file, buffer, size); }
-Result PXIFS1_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifs1Handle, file, buffer, size); }
-Result PXIFSR_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifsRHandle, file, buffer, size); }
-Result PXIFSB_CalculateFileHashSHA256(FSPXI_File file, u32* buffer, u32 size) { return FSPXI_CalculateFileHashSHA256(pxifsBHandle, file, buffer, size); }
-
-Result PXIFS0_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifs0Handle, file, bytesWritten, offset, buffer, size, flags); }
-Result PXIFS1_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifs1Handle, file, bytesWritten, offset, buffer, size, flags); }
-Result PXIFSR_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifsRHandle, file, bytesWritten, offset, buffer, size, flags); }
-Result PXIFSB_WriteFile(FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags) { return FSPXI_WriteFile(pxifsBHandle, file, bytesWritten, offset, buffer, size, flags); }
-
-Result PXIFS0_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifs0Handle, file, inBuffer, inSize, outBuffer, outSize); }
-Result PXIFS1_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifs1Handle, file, inBuffer, inSize, outBuffer, outSize); }
-Result PXIFSR_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifsRHandle, file, inBuffer, inSize, outBuffer, outSize); }
-Result PXIFSB_CalcSavegameMAC(FSPXI_File file, void* inBuffer, u32 inSize, void* outBuffer, u32 outSize) { return FSPXI_CalcSavegameMAC(pxifsBHandle, file, inBuffer, inSize, outBuffer, outSize); }
-
-Result PXIFS0_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifs0Handle, file, size); }
-Result PXIFS1_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifs1Handle, file, size); }
-Result PXIFSR_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifsRHandle, file, size); }
-Result PXIFSB_GetFileSize(FSPXI_File file, u64* size) { return FSPXI_GetFileSize(pxifsBHandle, file, size); }
-
-Result PXIFS0_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifs0Handle, file, size); }
-Result PXIFS1_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifs1Handle, file, size); }
-Result PXIFSR_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifsRHandle, file, size); }
-Result PXIFSB_SetFileSize(FSPXI_File file, u64 size) { return FSPXI_SetFileSize(pxifsBHandle, file, size); }
-
-Result PXIFS0_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifs0Handle, file); }
-Result PXIFS1_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifs1Handle, file); }
-Result PXIFSR_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifsRHandle, file); }
-Result PXIFSB_CloseFile(FSPXI_File file) { return FSPXI_CloseFile(pxifsBHandle, file); }
-
-Result PXIFS0_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifs0Handle, directory, entriesRead, entryCount, entries); }
-Result PXIFS1_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifs1Handle, directory, entriesRead, entryCount, entries); }
-Result PXIFSR_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifsRHandle, directory, entriesRead, entryCount, entries); }
-Result PXIFSB_ReadDirectory(FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries) { return FSPXI_ReadDirectory(pxifsBHandle, directory, entriesRead, entryCount, entries); }
-
-Result PXIFS0_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifs0Handle, directory); }
-Result PXIFS1_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifs1Handle, directory); }
-Result PXIFSR_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifsRHandle, directory); }
-Result PXIFSB_CloseDirectory(FSPXI_Directory directory) { return FSPXI_CloseDirectory(pxifsBHandle, directory); }
-
-Result PXIFS0_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifs0Handle, archive, archiveID, path); }
-Result PXIFS1_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifs1Handle, archive, archiveID, path); }
-Result PXIFSR_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifsRHandle, archive, archiveID, path); }
-Result PXIFSB_OpenArchive(FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path) { return FSPXI_OpenArchive(pxifsBHandle, archive, archiveID, path); }
-
-Result PXIFS0_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifs0Handle, archive, out, path); }
-Result PXIFS1_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifs1Handle, archive, out, path); }
-Result PXIFSR_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifsRHandle, archive, out, path); }
-Result PXIFSB_0x13(FSPXI_Archive archive, u8* out, FS_Path path) { return FSPXI_0x13(pxifsBHandle, archive, out, path); }
-
-Result PXIFS0_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifs0Handle, archive, out, path); }
-Result PXIFS1_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifs1Handle, archive, out, path); }
-Result PXIFSR_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifsRHandle, archive, out, path); }
-Result PXIFSB_0x14(FSPXI_Archive archive, u32* out, FS_Path path) { return FSPXI_0x14(pxifsBHandle, archive, out, path); }
-
-Result PXIFS0_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifs0Handle, archive, unknown); }
-Result PXIFS1_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifs1Handle, archive, unknown); }
-Result PXIFSR_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifsRHandle, archive, unknown); }
-Result PXIFSB_CommitSaveData(FSPXI_Archive archive, u32 unknown) { return FSPXI_CommitSaveData(pxifsBHandle, archive, unknown); }
-
-Result PXIFS0_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifs0Handle, archive); }
-Result PXIFS1_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifs1Handle, archive); }
-Result PXIFSR_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifsRHandle, archive); }
-Result PXIFSB_CloseArchive(FSPXI_Archive archive) { return FSPXI_CloseArchive(pxifsBHandle, archive); }
-
-Result PXIFS0_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifs0Handle, archive, out); }
-Result PXIFS1_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifs1Handle, archive, out); }
-Result PXIFSR_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifsRHandle, archive, out); }
-Result PXIFSB_0x17(FSPXI_Archive archive, bool* out) { return FSPXI_0x17(pxifsBHandle, archive, out); }
-
-Result PXIFS0_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifs0Handle, out); }
-Result PXIFS1_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifs1Handle, out); }
-Result PXIFSR_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifsRHandle, out); }
-Result PXIFSB_GetCardType(FS_CardType* out) { return FSPXI_GetCardType(pxifsBHandle, out); }
-
-Result PXIFS0_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifs0Handle, out); }
-Result PXIFS1_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifs1Handle, out); }
-Result PXIFSR_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifsRHandle, out); }
-Result PXIFSB_GetSdmcArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetSdmcArchiveResource(pxifsBHandle, out); }
-
-Result PXIFS0_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifs0Handle, out); }
-Result PXIFS1_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifs1Handle, out); }
-Result PXIFSR_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifsRHandle, out); }
-Result PXIFSB_GetNandArchiveResource(FS_ArchiveResource* out) { return FSPXI_GetNandArchiveResource(pxifsBHandle, out); }
-
-Result PXIFS0_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifs0Handle, out); }
-Result PXIFS1_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifs1Handle, out); }
-Result PXIFSR_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifsRHandle, out); }
-Result PXIFSB_GetSdmcFatFsError(u32* out) { return FSPXI_GetSdmcFatFsError(pxifsBHandle, out); }
-
-Result PXIFS0_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifs0Handle, out); }
-Result PXIFS1_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifs1Handle, out); }
-Result PXIFSR_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifsRHandle, out); }
-Result PXIFSB_IsSdmcDetected(bool* out) { return FSPXI_IsSdmcDetected(pxifsBHandle, out); }
-
-Result PXIFS0_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifs0Handle, out); }
-Result PXIFS1_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifs1Handle, out); }
-Result PXIFSR_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifsRHandle, out); }
-Result PXIFSB_IsSdmcWritable(bool* out) { return FSPXI_IsSdmcWritable(pxifsBHandle, out); }
-
-Result PXIFS0_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifs0Handle, out, size); }
-Result PXIFS1_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifs1Handle, out, size); }
-Result PXIFSR_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifsRHandle, out, size); }
-Result PXIFSB_GetSdmcCid(void* out, u32 size) { return FSPXI_GetSdmcCid(pxifsBHandle, out, size); }
-
-Result PXIFS0_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifs0Handle, out, size); }
-Result PXIFS1_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifs1Handle, out, size); }
-Result PXIFSR_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifsRHandle, out, size); }
-Result PXIFSB_GetNandCid(void* out, u32 size) { return FSPXI_GetNandCid(pxifsBHandle, out, size); }
-
-Result PXIFS0_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifs0Handle, out); }
-Result PXIFS1_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifs1Handle, out); }
-Result PXIFSR_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifsRHandle, out); }
-Result PXIFSB_GetSdmcSpeedInfo(u32* out) { return FSPXI_GetSdmcSpeedInfo(pxifsBHandle, out); }
-
-Result PXIFS0_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifs0Handle, out); }
-Result PXIFS1_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifs1Handle, out); }
-Result PXIFSR_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifsRHandle, out); }
-Result PXIFSB_GetNandSpeedInfo(u32* out) { return FSPXI_GetNandSpeedInfo(pxifsBHandle, out); }
-
-Result PXIFS0_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifs0Handle, out, size); }
-Result PXIFS1_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifs1Handle, out, size); }
-Result PXIFSR_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifsRHandle, out, size); }
-Result PXIFSB_GetSdmcLog(void* out, u32 size) { return FSPXI_GetSdmcLog(pxifsBHandle, out, size); }
-
-Result PXIFS0_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifs0Handle, out, size); }
-Result PXIFS1_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifs1Handle, out, size); }
-Result PXIFSR_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifsRHandle, out, size); }
-Result PXIFSB_GetNandLog(void* out, u32 size) { return FSPXI_GetNandLog(pxifsBHandle, out, size); }
-
-Result PXIFS0_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifs0Handle); }
-Result PXIFS1_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifs1Handle); }
-Result PXIFSR_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifsRHandle); }
-Result PXIFSB_ClearSdmcLog(void) { return FSPXI_ClearSdmcLog(pxifsBHandle); }
-
-Result PXIFS0_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifs0Handle); }
-Result PXIFS1_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifs1Handle); }
-Result PXIFSR_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifsRHandle); }
-Result PXIFSB_ClearNandLog(void) { return FSPXI_ClearNandLog(pxifsBHandle); }
-
-Result PXIFS0_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifs0Handle, inserted); }
-Result PXIFS1_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifs1Handle, inserted); }
-Result PXIFSR_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifsRHandle, inserted); }
-Result PXIFSB_CardSlotIsInserted(bool* inserted) { return FSPXI_CardSlotIsInserted(pxifsBHandle, inserted); }
-
-Result PXIFS0_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifs0Handle, status); }
-Result PXIFS1_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifs1Handle, status); }
-Result PXIFSR_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifsRHandle, status); }
-Result PXIFSB_CardSlotPowerOn(bool* status) { return FSPXI_CardSlotPowerOn(pxifsBHandle, status); }
-
-Result PXIFS0_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifs0Handle, status); }
-Result PXIFS1_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifs1Handle, status); }
-Result PXIFSR_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifsRHandle, status); }
-Result PXIFSB_CardSlotPowerOff(bool* status) { return FSPXI_CardSlotPowerOff(pxifsBHandle, status); }
-
-Result PXIFS0_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifs0Handle, status); }
-Result PXIFS1_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifs1Handle, status); }
-Result PXIFSR_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifsRHandle, status); }
-Result PXIFSB_CardSlotGetCardIFPowerStatus(bool* status) { return FSPXI_CardSlotGetCardIFPowerStatus(pxifsBHandle, status); }
-
-Result PXIFS0_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifs0Handle, commandId); }
-Result PXIFS1_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifs1Handle, commandId); }
-Result PXIFSR_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifsRHandle, commandId); }
-Result PXIFSB_CardNorDirectCommand(u8 commandId) { return FSPXI_CardNorDirectCommand(pxifsBHandle, commandId); }
-
-Result PXIFS0_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifs0Handle, commandId, address); }
-Result PXIFS1_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifs1Handle, commandId, address); }
-Result PXIFSR_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifsRHandle, commandId, address); }
-Result PXIFSB_CardNorDirectCommandWithAddress(u8 commandId, u32 address) { return FSPXI_CardNorDirectCommandWithAddress(pxifsBHandle, commandId, address); }
-
-Result PXIFS0_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifs0Handle, commandId, size, output); }
-Result PXIFS1_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifs1Handle, commandId, size, output); }
-Result PXIFSR_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifsRHandle, commandId, size, output); }
-Result PXIFSB_CardNorDirectRead(u8 commandId, u32 size, u8* output) { return FSPXI_CardNorDirectRead(pxifsBHandle, commandId, size, output); }
-
-Result PXIFS0_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifs0Handle, commandId, address, size, output); }
-Result PXIFS1_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifs1Handle, commandId, address, size, output); }
-Result PXIFSR_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifsRHandle, commandId, address, size, output); }
-Result PXIFSB_CardNorDirectReadWithAddress(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectReadWithAddress(pxifsBHandle, commandId, address, size, output); }
-
-Result PXIFS0_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifs0Handle, commandId, size, input); }
-Result PXIFS1_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifs1Handle, commandId, size, input); }
-Result PXIFSR_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifsRHandle, commandId, size, input); }
-Result PXIFSB_CardNorDirectWrite(u8 commandId, u32 size, u8* input) { return FSPXI_CardNorDirectWrite(pxifsBHandle, commandId, size, input); }
-
-Result PXIFS0_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifs0Handle, commandId, address, size, input); }
-Result PXIFS1_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifs1Handle, commandId, address, size, input); }
-Result PXIFSR_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifsRHandle, commandId, address, size, input); }
-Result PXIFSB_CardNorDirectWriteWithAddress(u8 commandId, u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectWriteWithAddress(pxifsBHandle, commandId, address, size, input); }
-
-Result PXIFS0_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifs0Handle, commandId, address, size, output); }
-Result PXIFS1_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifs1Handle, commandId, address, size, output); }
-Result PXIFSR_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifsRHandle, commandId, address, size, output); }
-Result PXIFSB_CardNorDirectRead_4xIO(u8 commandId, u32 address, u32 size, u8* output) { return FSPXI_CardNorDirectRead_4xIO(pxifsBHandle, commandId, address, size, output); }
-
-Result PXIFS0_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifs0Handle, address, size, input); }
-Result PXIFS1_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifs1Handle, address, size, input); }
-Result PXIFSR_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifsRHandle, address, size, input); }
-Result PXIFSB_CardNorDirectCpuWriteWithoutVerify(u32 address, u32 size, u8* input) { return FSPXI_CardNorDirectCpuWriteWithoutVerify(pxifsBHandle, address, size, input); }
-
-Result PXIFS0_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifs0Handle, address); }
-Result PXIFS1_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifs1Handle, address); }
-Result PXIFSR_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifsRHandle, address); }
-Result PXIFSB_CardNorDirectSectorEraseWithoutVerify(u32 address) { return FSPXI_CardNorDirectSectorEraseWithoutVerify(pxifsBHandle, address); }
-
-Result PXIFS0_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifs0Handle, info, archive); }
-Result PXIFS1_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifs1Handle, info, archive); }
-Result PXIFSR_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifsRHandle, info, archive); }
-Result PXIFSB_GetProductInfo(FS_ProductInfo* info, FSPXI_Archive archive) { return FSPXI_GetProductInfo(pxifsBHandle, info, archive); }
-
-Result PXIFS0_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifs0Handle, baudRate); }
-Result PXIFS1_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifs1Handle, baudRate); }
-Result PXIFSR_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifsRHandle, baudRate); }
-Result PXIFSB_SetCardSpiBaudrate(FS_CardSpiBaudRate baudRate) { return FSPXI_SetCardSpiBaudrate(pxifsBHandle, baudRate); }
-
-Result PXIFS0_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifs0Handle, busMode); }
-Result PXIFS1_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifs1Handle, busMode); }
-Result PXIFSR_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifsRHandle, busMode); }
-Result PXIFSB_SetCardSpiBusMode(FS_CardSpiBusMode busMode) { return FSPXI_SetCardSpiBusMode(pxifsBHandle, busMode); }
-
-Result PXIFS0_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifs0Handle, unk); }
-Result PXIFS1_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifs1Handle, unk); }
-Result PXIFSR_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifsRHandle, unk); }
-Result PXIFSB_SendInitializeInfoTo9(u8 unk) { return FSPXI_SendInitializeInfoTo9(pxifsBHandle, unk); }
-
-Result PXIFS0_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifs0Handle, info); }
-Result PXIFS1_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifs1Handle, info); }
-Result PXIFSR_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifsRHandle, info); }
-Result PXIFSB_CreateExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_CreateExtSaveData(pxifsBHandle, info); }
-
-Result PXIFS0_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifs0Handle, info); }
-Result PXIFS1_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifs1Handle, info); }
-Result PXIFSR_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifsRHandle, info); }
-Result PXIFSB_DeleteExtSaveData(FS_ExtSaveDataInfo info) { return FSPXI_DeleteExtSaveData(pxifsBHandle, info); }
-
-Result PXIFS0_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifs0Handle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
-Result PXIFS1_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifs1Handle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
-Result PXIFSR_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifsRHandle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
-Result PXIFSB_EnumerateExtSaveData(u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids) { return FSPXI_EnumerateExtSaveData(pxifsBHandle, idsWritten, idsSize, mediaType, idSize, shared, ids); }
-
-Result PXIFS0_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifs0Handle, index, mediaType, programId, type); }
-Result PXIFS1_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifs1Handle, index, mediaType, programId, type); }
-Result PXIFSR_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifsRHandle, index, mediaType, programId, type); }
-Result PXIFSB_GetSpecialContentIndex(u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type) { return FSPXI_GetSpecialContentIndex(pxifsBHandle, index, mediaType, programId, type); }
-
-Result PXIFS0_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifs0Handle, mediaType, programId, header); }
-Result PXIFS1_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifs1Handle, mediaType, programId, header); }
-Result PXIFSR_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifsRHandle, mediaType, programId, header); }
-Result PXIFSB_GetLegacyRomHeader(FS_MediaType mediaType, u64 programId, u8* header) { return FSPXI_GetLegacyRomHeader(pxifsBHandle, mediaType, programId, header); }
-
-Result PXIFS0_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifs0Handle, mediaType, programId, banner, unk); }
-Result PXIFS1_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifs1Handle, mediaType, programId, banner, unk); }
-Result PXIFSR_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifsRHandle, mediaType, programId, banner, unk); }
-Result PXIFSB_GetLegacyBannerData(FS_MediaType mediaType, u64 programId, u8* banner, u32 unk) { return FSPXI_GetLegacyBannerData(pxifsBHandle, mediaType, programId, banner, unk); }
-
-Result PXIFS0_0x3D(u32 unk) { return FSPXI_0x3D(pxifs0Handle, unk); }
-Result PXIFS1_0x3D(u32 unk) { return FSPXI_0x3D(pxifs1Handle, unk); }
-Result PXIFSR_0x3D(u32 unk) { return FSPXI_0x3D(pxifsRHandle, unk); }
-Result PXIFSB_0x3D(u32 unk) { return FSPXI_0x3D(pxifsBHandle, unk); }
-
-Result PXIFS0_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifs0Handle); }
-Result PXIFS1_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifs1Handle); }
-Result PXIFSR_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifsRHandle); }
-Result PXIFSB_DeleteSdmcRoot(void) { return FSPXI_DeleteSdmcRoot(pxifsBHandle); }
-
-Result PXIFS0_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifs0Handle); }
-Result PXIFS1_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifs1Handle); }
-Result PXIFSR_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifsRHandle); }
-Result PXIFSB_DeleteAllExtSaveDataOnNand(void) { return FSPXI_DeleteAllExtSaveDataOnNand(pxifsBHandle); }
-
-Result PXIFS0_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifs0Handle); }
-Result PXIFS1_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifs1Handle); }
-Result PXIFSR_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifsRHandle); }
-Result PXIFSB_InitializeCtrFilesystem(void) { return FSPXI_InitializeCtrFilesystem(pxifsBHandle); }
-
-Result PXIFS0_CreateSeed(void) { return FSPXI_CreateSeed(pxifs0Handle); }
-Result PXIFS1_CreateSeed(void) { return FSPXI_CreateSeed(pxifs1Handle); }
-Result PXIFSR_CreateSeed(void) { return FSPXI_CreateSeed(pxifsRHandle); }
-Result PXIFSB_CreateSeed(void) { return FSPXI_CreateSeed(pxifsBHandle); }
-
-Result PXIFS0_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifs0Handle, out, length); }
-Result PXIFS1_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifs1Handle, out, length); }
-Result PXIFSR_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifsRHandle, out, length); }
-Result PXIFSB_GetSdmcCtrRootPath(u8* out, u32 length) { return FSPXI_GetSdmcCtrRootPath(pxifsBHandle, out, length); }
-
-Result PXIFS0_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifs0Handle, archiveResource, mediaType); }
-Result PXIFS1_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifs1Handle, archiveResource, mediaType); }
-Result PXIFSR_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifsRHandle, archiveResource, mediaType); }
-Result PXIFSB_GetArchiveResource(FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType) { return FSPXI_GetArchiveResource(pxifsBHandle, archiveResource, mediaType); }
-
-Result PXIFS0_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifs0Handle, seed); }
-Result PXIFS1_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifs1Handle, seed); }
-Result PXIFSR_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifsRHandle, seed); }
-Result PXIFSB_ExportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ExportIntegrityVerificationSeed(pxifsBHandle, seed); }
-
-Result PXIFS0_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifs0Handle, seed); }
-Result PXIFS1_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifs1Handle, seed); }
-Result PXIFSR_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifsRHandle, seed); }
-Result PXIFSB_ImportIntegrityVerificationSeed(FS_IntegrityVerificationSeed* seed) { return FSPXI_ImportIntegrityVerificationSeed(pxifsBHandle, seed); }
-
-Result PXIFS0_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifs0Handle, bannerSize, mediaType, programId, banner); }
-Result PXIFS1_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifs1Handle, bannerSize, mediaType, programId, banner); }
-Result PXIFSR_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifsRHandle, bannerSize, mediaType, programId, banner); }
-Result PXIFSB_GetLegacySubBannerData(u32 bannerSize, FS_MediaType mediaType, u64 programId, u8* banner) { return FSPXI_GetLegacySubBannerData(pxifsBHandle, bannerSize, mediaType, programId, banner); }
-
-Result PXIFS0_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifs0Handle, buf, size); }
-Result PXIFS1_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifs1Handle, buf, size); }
-Result PXIFSR_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifsRHandle, buf, size); }
-Result PXIFSB_0x47(void* buf, u32 size) { return FSPXI_0x47(pxifsBHandle, buf, size); }
-
-Result PXIFS0_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifs0Handle, archive, out, path, size); }
-Result PXIFS1_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifs1Handle, archive, out, path, size); }
-Result PXIFSR_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifsRHandle, archive, out, path, size); }
-Result PXIFSB_GetFileLastModified(FSPXI_Archive archive, u64* out, u16* path, u32 size) { return FSPXI_GetFileLastModified(pxifsBHandle, archive, out, path, size); }
-
-Result PXIFS0_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifs0Handle, bytesRead, fileOffset, size, data); }
-Result PXIFS1_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifs1Handle, bytesRead, fileOffset, size, data); }
-Result PXIFSR_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifsRHandle, bytesRead, fileOffset, size, data); }
-Result PXIFSB_ReadSpecialFile(u32* bytesRead, u64 fileOffset, u32 size, u8* data) { return FSPXI_ReadSpecialFile(pxifsBHandle, bytesRead, fileOffset, size, data); }
-
-Result PXIFS0_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifs0Handle, fileSize); }
-Result PXIFS1_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifs1Handle, fileSize); }
-Result PXIFSR_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifsRHandle, fileSize); }
-Result PXIFSB_GetSpecialFileSize(u64* fileSize) { return FSPXI_GetSpecialFileSize(pxifsBHandle, fileSize); }
-
-Result PXIFS0_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifs0Handle, context); }
-Result PXIFS1_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifs1Handle, context); }
-Result PXIFSR_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifsRHandle, context); }
-Result PXIFSB_StartDeviceMoveAsSource(FS_DeviceMoveContext* context) { return FSPXI_StartDeviceMoveAsSource(pxifsBHandle, context); }
-
-Result PXIFS0_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifs0Handle, context, clear); }
-Result PXIFS1_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifs1Handle, context, clear); }
-Result PXIFSR_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifsRHandle, context, clear); }
-Result PXIFSB_StartDeviceMoveAsDestination(FS_DeviceMoveContext context, bool clear) { return FSPXI_StartDeviceMoveAsDestination(pxifsBHandle, context, clear); }
-
-Result PXIFS0_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifs0Handle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
-Result PXIFS1_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifs1Handle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
-Result PXIFSR_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifsRHandle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
-Result PXIFSB_ReadFileSHA256(FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk) { return FSPXI_ReadFileSHA256(pxifsBHandle, file, bytesRead, offset, readBuffer, readBufferSize, hashtable, hashtableSize, unk); }
-
-Result PXIFS0_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifs0Handle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
-Result PXIFS1_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifs1Handle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
-Result PXIFSR_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifsRHandle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
-Result PXIFSB_WriteFileSHA256(FSPXI_File file, u32* bytesWritten, u64 offset, void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2) { return FSPXI_WriteFileSHA256(pxifsBHandle, file, bytesWritten, offset, writeBuffer, writeBufferSize, hashtable, hashtableSize, unk1, unk2); }
-
-Result PXIFS0_0x4F(u64 unk) { return FSPXI_0x4F(pxifs0Handle, unk); }
-Result PXIFS1_0x4F(u64 unk) { return FSPXI_0x4F(pxifs1Handle, unk); }
-Result PXIFSR_0x4F(u64 unk) { return FSPXI_0x4F(pxifsRHandle, unk); }
-Result PXIFSB_0x4F(u64 unk) { return FSPXI_0x4F(pxifsBHandle, unk); }
-
-Result PXIFS0_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifs0Handle, priority); }
-Result PXIFS1_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifs1Handle, priority); }
-Result PXIFSR_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifsRHandle, priority); }
-Result PXIFSB_SetPriority(u32 priority) { return FSPXI_SetPriority(pxifsBHandle, priority); }
-
-Result PXIFS0_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifs0Handle, enable); }
-Result PXIFS1_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifs1Handle, enable); }
-Result PXIFSR_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifsRHandle, enable); }
-Result PXIFSB_SwitchCleanupInvalidSaveData(bool enable) { return FSPXI_SwitchCleanupInvalidSaveData(pxifsBHandle, enable); }
-
-Result PXIFS0_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifs0Handle, idsWritten, idsSize, ids); }
-Result PXIFS1_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifs1Handle, idsWritten, idsSize, ids); }
-Result PXIFSR_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifsRHandle, idsWritten, idsSize, ids); }
-Result PXIFSB_EnumerateSystemSaveData(u32* idsWritten, u32 idsSize, u32* ids) { return FSPXI_EnumerateSystemSaveData(pxifsBHandle, idsWritten, idsSize, ids); }
-
-Result PXIFS0_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifs0Handle, buffer, size, unk); }
-Result PXIFS1_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifs1Handle, buffer, size, unk); }
-Result PXIFSR_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifsRHandle, buffer, size, unk); }
-Result PXIFSB_ReadNandReport(void* buffer, u32 size, u32 unk) { return FSPXI_ReadNandReport(pxifsBHandle, buffer, size, unk); }
-
-Result PXIFS0_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifs0Handle, out, archive, path); }
-Result PXIFS1_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifs1Handle, out, archive, path); }
-Result PXIFSR_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifsRHandle, out, archive, path); }
-Result PXIFSB_0x56(u32 (*out)[4], FS_Archive archive, FS_Path path) { return FSPXI_0x56(pxifsBHandle, out, archive, path); }

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -9,214 +9,214 @@
 
 Result FSPXI_OpenFile(Handle serviceHandle, FSPXI_File* out, FSPXI_Archive archive, FS_Path path, u32 flags, u32 attributes)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1, 7, 2); // 0x000101C2
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) archive;
-    cmdbuf[3] = (u32)(archive >> 32);
-    cmdbuf[4] = path.type;
-    cmdbuf[5] = path.size;
-    cmdbuf[6] = flags;
-    cmdbuf[7] = attributes;
-    cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[9] = (u32) path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x1, 7, 2); // 0x000101C2
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) archive;
+	cmdbuf[3] = (u32)(archive >> 32);
+	cmdbuf[4] = path.type;
+	cmdbuf[5] = path.size;
+	cmdbuf[6] = flags;
+	cmdbuf[7] = attributes;
+	cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[9] = (u32) path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_DeleteFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x2, 5, 2); // 0x00020142
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) archive;
-    cmdbuf[3] = (u32)(archive >> 32);
-    cmdbuf[4] = path.type;
-    cmdbuf[5] = path.size;
-    cmdbuf[6] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[7] = (u32) path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x2, 5, 2); // 0x00020142
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) archive;
+	cmdbuf[3] = (u32)(archive >> 32);
+	cmdbuf[4] = path.type;
+	cmdbuf[5] = path.size;
+	cmdbuf[6] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[7] = (u32) path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_RenameFile(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3, 9, 4); // 0x00030244
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) srcArchive;
-    cmdbuf[3] = (u32)(srcArchive >> 32);
-    cmdbuf[4] = srcPath.type;
-    cmdbuf[5] = srcPath.size;
-    cmdbuf[6] = (u32) dstArchive;
-    cmdbuf[7] = (u32)(dstArchive >> 32);
-    cmdbuf[8] = dstPath.type;
-    cmdbuf[9] = dstPath.size;
-    cmdbuf[10] = IPC_Desc_PXIBuffer(srcPath.size, 0, true);
-    cmdbuf[11] = (u32) srcPath.data;
-    cmdbuf[12] = IPC_Desc_PXIBuffer(dstPath.size, 1, true);
-    cmdbuf[13] = (u32) dstPath.data;
+	cmdbuf[0] = IPC_MakeHeader(0x3, 9, 4); // 0x00030244
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) srcArchive;
+	cmdbuf[3] = (u32)(srcArchive >> 32);
+	cmdbuf[4] = srcPath.type;
+	cmdbuf[5] = srcPath.size;
+	cmdbuf[6] = (u32) dstArchive;
+	cmdbuf[7] = (u32)(dstArchive >> 32);
+	cmdbuf[8] = dstPath.type;
+	cmdbuf[9] = dstPath.size;
+	cmdbuf[10] = IPC_Desc_PXIBuffer(srcPath.size, 0, true);
+	cmdbuf[11] = (u32) srcPath.data;
+	cmdbuf[12] = IPC_Desc_PXIBuffer(dstPath.size, 1, true);
+	cmdbuf[13] = (u32) dstPath.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_DeleteDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x4, 5, 2); // 0x00040142
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) archive;
-    cmdbuf[3] = (u32)(archive >> 32);
-    cmdbuf[4] = path.type;
-    cmdbuf[5] = path.size;
-    cmdbuf[6] = IPC_Desc_PXIBuffer(path.size, 0, false);
-    cmdbuf[7] = (u32) path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x4, 5, 2); // 0x00040142
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) archive;
+	cmdbuf[3] = (u32)(archive >> 32);
+	cmdbuf[4] = path.type;
+	cmdbuf[5] = path.size;
+	cmdbuf[6] = IPC_Desc_PXIBuffer(path.size, 0, false);
+	cmdbuf[7] = (u32) path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes, u64 fileSize)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x5, 8, 2); // 0x00050202
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) archive;
-    cmdbuf[3] = (u32)(archive >> 32);
-    cmdbuf[4] = path.type;
-    cmdbuf[5] = path.size;
-    cmdbuf[6] = attributes;
-    cmdbuf[7] = (u32)fileSize;
-    cmdbuf[8] = (u32)(fileSize >> 32);
-    cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[9] = (u32) path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x5, 8, 2); // 0x00050202
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) archive;
+	cmdbuf[3] = (u32)(archive >> 32);
+	cmdbuf[4] = path.type;
+	cmdbuf[5] = path.size;
+	cmdbuf[6] = attributes;
+	cmdbuf[7] = (u32)fileSize;
+	cmdbuf[8] = (u32)(fileSize >> 32);
+	cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[9] = (u32) path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CreateDirectory(Handle serviceHandle, FSPXI_Archive archive, FS_Path path, u32 attributes)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x6, 6, 2); // 0x00060182
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) archive;
-    cmdbuf[3] = (u32)(archive >> 32);
-    cmdbuf[4] = path.type;
-    cmdbuf[5] = path.size;
-    cmdbuf[6] = attributes;
-    cmdbuf[7] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[8] = (u32) path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x6, 6, 2); // 0x00060182
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) archive;
+	cmdbuf[3] = (u32)(archive >> 32);
+	cmdbuf[4] = path.type;
+	cmdbuf[5] = path.size;
+	cmdbuf[6] = attributes;
+	cmdbuf[7] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[8] = (u32) path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_RenameDirectory(Handle serviceHandle, FSPXI_Archive srcArchive, FS_Path srcPath, FSPXI_Archive dstArchive, FS_Path dstPath)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x7, 9, 4); // 0x00070244
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) srcArchive;
-    cmdbuf[3] = (u32)(srcArchive >> 32);
-    cmdbuf[4] = srcPath.type;
-    cmdbuf[5] = srcPath.size;
-    cmdbuf[6] = (u32) dstArchive;
-    cmdbuf[7] = (u32)(dstArchive >> 32);
-    cmdbuf[8] = dstPath.type;
-    cmdbuf[9] = dstPath.size;
-    cmdbuf[10] = IPC_Desc_PXIBuffer(srcPath.size, 0, true);
-    cmdbuf[11] = (u32) srcPath.data;
-    cmdbuf[12] = IPC_Desc_PXIBuffer(dstPath.size, 1, true);
-    cmdbuf[13] = (u32) dstPath.data;
+	cmdbuf[0] = IPC_MakeHeader(0x7, 9, 4); // 0x00070244
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) srcArchive;
+	cmdbuf[3] = (u32)(srcArchive >> 32);
+	cmdbuf[4] = srcPath.type;
+	cmdbuf[5] = srcPath.size;
+	cmdbuf[6] = (u32) dstArchive;
+	cmdbuf[7] = (u32)(dstArchive >> 32);
+	cmdbuf[8] = dstPath.type;
+	cmdbuf[9] = dstPath.size;
+	cmdbuf[10] = IPC_Desc_PXIBuffer(srcPath.size, 0, true);
+	cmdbuf[11] = (u32) srcPath.data;
+	cmdbuf[12] = IPC_Desc_PXIBuffer(dstPath.size, 1, true);
+	cmdbuf[13] = (u32) dstPath.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_OpenDirectory(Handle serviceHandle, FSPXI_Directory* out, FSPXI_Archive archive, FS_Path path)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x8, 4, 2); // 0x00080102
-    cmdbuf[1] = 0; // transaction
-    cmdbuf[2] = (u32) archive;
-    cmdbuf[3] = (u32)(archive >> 32);
-    cmdbuf[4] = path.type;
-    cmdbuf[5] = path.size;
-    cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[9] = (u32) path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x8, 4, 2); // 0x00080102
+	cmdbuf[1] = 0; // transaction
+	cmdbuf[2] = (u32) archive;
+	cmdbuf[3] = (u32)(archive >> 32);
+	cmdbuf[4] = path.type;
+	cmdbuf[5] = path.size;
+	cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[9] = (u32) path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ReadFile(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* buffer, u32 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x9, 5, 2); // 0x00090142
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32)(file >> 32);
-    cmdbuf[3] = (u32) offset;
-    cmdbuf[4] = (u32)(offset >> 32);
-    cmdbuf[5] = size;
-    cmdbuf[6] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[7] = (u32) buffer;
+	cmdbuf[0] = IPC_MakeHeader(0x9, 5, 2); // 0x00090142
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32)(file >> 32);
+	cmdbuf[3] = (u32) offset;
+	cmdbuf[4] = (u32)(offset >> 32);
+	cmdbuf[5] = size;
+	cmdbuf[6] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[7] = (u32) buffer;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(bytesRead) *bytesRead = cmdbuf[2];
+	if(bytesRead) *bytesRead = cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, u32* buffer, u32 size)
+Result FSPXI_CalculateFileHashSHA256(Handle serviceHandle, FSPXI_File file, void* buffer, u32 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0xA, 3, 2); // 0x000A00C2
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32)(file >> 32);
-    cmdbuf[3] = size;
-    cmdbuf[4] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[5] = (u32) buffer;
+	cmdbuf[0] = IPC_MakeHeader(0xA, 3, 2); // 0x000A00C2
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32)(file >> 32);
+	cmdbuf[3] = size;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[5] = (u32) buffer;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* buffer, u32 size, u32 flags)
@@ -225,8 +225,8 @@ Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten,
 	u32 *cmdbuf = getThreadCommandBuffer();
 
 	cmdbuf[0] = IPC_MakeHeader(0xB,6,2); // 0x000B0182
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32)(file >> 32);
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32)(file >> 32);
 	cmdbuf[3] = (u32) offset;
 	cmdbuf[4] = (u32) (offset >> 32);
 	cmdbuf[5] = flags;
@@ -243,471 +243,471 @@ Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten,
 
 Result FSPXI_CalcSavegameMAC(Handle serviceHandle, FSPXI_File file, const void* inBuffer, u32 inSize, void* outBuffer, u32 outSize)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0xC, 4, 4);
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32)(file >> 32);
-    cmdbuf[3] = outSize;
-    cmdbuf[4] = inSize;
-    cmdbuf[5] = IPC_Desc_PXIBuffer(inSize, 0, true);
-    cmdbuf[6] = (u32) inBuffer;
-    cmdbuf[7] = IPC_Desc_PXIBuffer(outSize, 1, false);
-    cmdbuf[8] = (u32) outBuffer;
+	cmdbuf[0] = IPC_MakeHeader(0xC, 4, 4);
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32)(file >> 32);
+	cmdbuf[3] = outSize;
+	cmdbuf[4] = inSize;
+	cmdbuf[5] = IPC_Desc_PXIBuffer(inSize, 0, true);
+	cmdbuf[6] = (u32) inBuffer;
+	cmdbuf[7] = IPC_Desc_PXIBuffer(outSize, 1, false);
+	cmdbuf[8] = (u32) outBuffer;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetFileSize(Handle serviceHandle, FSPXI_File file, u64* size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0xD, 2, 0); // 0x000D0080
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32) (file >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0xD, 2, 0); // 0x000D0080
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32) (file >> 32);
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (size) *size = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	if (size) *size = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_SetFileSize(Handle serviceHandle, FSPXI_File file, u64 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0xE, 4, 0); // 0x000E0100
-    cmdbuf[1] = (u32) size;
-    cmdbuf[2] = (u32) (size >> 32);
-    cmdbuf[3] = (u32) file;
-    cmdbuf[4] = (u32) (file >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0xE, 4, 0); // 0x000E0100
+	cmdbuf[1] = (u32) size;
+	cmdbuf[2] = (u32) (size >> 32);
+	cmdbuf[3] = (u32) file;
+	cmdbuf[4] = (u32) (file >> 32);
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CloseFile(Handle serviceHandle, FSPXI_File file)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0xF, 2, 0); // 0x000F0080
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32) (file >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0xF, 2, 0); // 0x000F0080
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32) (file >> 32);
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ReadDirectory(Handle serviceHandle, FSPXI_Directory directory, u32* entriesRead, u32 entryCount, FS_DirectoryEntry* entries)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x10, 3, 2); // 0x001000C2
-    cmdbuf[1] = (u32) directory;
-    cmdbuf[2] = (u32) (directory >> 32);
-    cmdbuf[3] = entryCount;
-    cmdbuf[4] = IPC_Desc_PXIBuffer(sizeof(FS_DirectoryEntry) * entryCount, 0, false);
-    cmdbuf[5] = (u32) entries;
+	cmdbuf[0] = IPC_MakeHeader(0x10, 3, 2); // 0x001000C2
+	cmdbuf[1] = (u32) directory;
+	cmdbuf[2] = (u32) (directory >> 32);
+	cmdbuf[3] = entryCount;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(sizeof(FS_DirectoryEntry) * entryCount, 0, false);
+	cmdbuf[5] = (u32) entries;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(entriesRead) *entriesRead = cmdbuf[2];
+	if(entriesRead) *entriesRead = cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CloseDirectory(Handle serviceHandle, FSPXI_Directory directory)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x11, 2, 0); // 0x00110080
-    cmdbuf[1] = (u32) directory;
-    cmdbuf[2] = (u32) (directory >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0x11, 2, 0); // 0x00110080
+	cmdbuf[1] = (u32) directory;
+	cmdbuf[2] = (u32) (directory >> 32);
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_ArchiveID archiveID, FS_Path path)
 {
-    if (!archive) return -2;
+	if (!archive) return -2;
 
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x12, 3, 2);
-    cmdbuf[1] = archiveID;
-    cmdbuf[2] = path.type;
-    cmdbuf[3] = path.size;
-    cmdbuf[4] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[5] = (u32)path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x12, 3, 2);
+	cmdbuf[1] = archiveID;
+	cmdbuf[2] = path.type;
+	cmdbuf[3] = path.size;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[5] = (u32)path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    *archive = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	*archive = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_HasFile(Handle serviceHandle, FSPXI_Archive archive, bool* out, FS_Path path)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x13, 4, 2); // 0x00130102
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
-    cmdbuf[3] = path.type;
-    cmdbuf[4] = path.size;
-    cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[6] = (u32)path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x13, 4, 2); // 0x00130102
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[3] = path.type;
+	cmdbuf[4] = path.size;
+	cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[6] = (u32)path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = (bool)cmdbuf[2];
+	if (out) *out = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_HasDirectory(Handle serviceHandle, FSPXI_Archive archive, bool* out, FS_Path path)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x14, 4, 2); // 0x00140102
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
-    cmdbuf[3] = path.type;
-    cmdbuf[4] = path.size;
-    cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[6] = (u32)path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x14, 4, 2); // 0x00140102
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[3] = path.type;
+	cmdbuf[4] = path.size;
+	cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[6] = (u32)path.data;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = (bool)cmdbuf[2];
+	if (out) *out = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CommitSaveData(Handle serviceHandle, FSPXI_Archive archive, u32 id)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x15, 3, 0); // 0x001500C0
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
-    cmdbuf[3] = id;
+	cmdbuf[0] = IPC_MakeHeader(0x15, 3, 0); // 0x001500C0
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[3] = id;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CloseArchive(Handle serviceHandle, FSPXI_Archive archive)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x16, 2, 0); // 0x00160080
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0x16, 2, 0); // 0x00160080
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_Unknown0x17(Handle serviceHandle, FSPXI_Archive archive, bool* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x17, 2, 0); // 0x00170080
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0x17, 2, 0); // 0x00170080
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = (bool)cmdbuf[2];
+	if (out) *out = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetCardType(Handle serviceHandle, FS_CardType* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x18, 0, 0); // 0x00180000
+	cmdbuf[0] = IPC_MakeHeader(0x18, 0, 0); // 0x00180000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out) *out = cmdbuf[2] & 0xFF;
+	if(out) *out = cmdbuf[2] & 0xFF;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetSdmcArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x19, 0, 0); // 0x00190000
+	cmdbuf[0] = IPC_MakeHeader(0x19, 0, 0); // 0x00190000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out)
-    {
-        out->sectorSize = cmdbuf[2];
-        out->clusterSize = cmdbuf[3];
-        out->totalClusters = cmdbuf[4];
-        out->freeClusters = cmdbuf[5];
-    }
+	if(out)
+	{
+		out->sectorSize = cmdbuf[2];
+		out->clusterSize = cmdbuf[3];
+		out->totalClusters = cmdbuf[4];
+		out->freeClusters = cmdbuf[5];
+	}
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetNandArchiveResource(Handle serviceHandle, FS_ArchiveResource* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1A, 0, 0); // 0x001A0000
+	cmdbuf[0] = IPC_MakeHeader(0x1A, 0, 0); // 0x001A0000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out)
-    {
-        out->sectorSize = cmdbuf[2];
-        out->clusterSize = cmdbuf[3];
-        out->totalClusters = cmdbuf[4];
-        out->freeClusters = cmdbuf[5];
-    }
+	if(out)
+	{
+		out->sectorSize = cmdbuf[2];
+		out->clusterSize = cmdbuf[3];
+		out->totalClusters = cmdbuf[4];
+		out->freeClusters = cmdbuf[5];
+	}
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetSdmcFatFsError(Handle serviceHandle, u32* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1B, 0, 0); // 0x001B0000
+	cmdbuf[0] = IPC_MakeHeader(0x1B, 0, 0); // 0x001B0000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out) *out = cmdbuf[2];
+	if(out) *out = cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_IsSdmcDetected(Handle serviceHandle, bool* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1C, 0, 0); // 0x001C0000
+	cmdbuf[0] = IPC_MakeHeader(0x1C, 0, 0); // 0x001C0000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out) *out = (bool)cmdbuf[2];
+	if(out) *out = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_IsSdmcWritable(Handle serviceHandle, bool* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1D, 0, 0); // 0x001D0000
+	cmdbuf[0] = IPC_MakeHeader(0x1D, 0, 0); // 0x001D0000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out) *out = (bool)cmdbuf[2];
+	if(out) *out = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetSdmcCid(Handle serviceHandle, void* out, u32 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1E, 0, 0); // 0x001E0000
-    cmdbuf[1] = size;
-    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[3] = (u32) out;
+	cmdbuf[0] = IPC_MakeHeader(0x1E, 0, 0); // 0x001E0000
+	cmdbuf[1] = size;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[3] = (u32) out;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetNandCid(Handle serviceHandle, void* out, u32 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x1F, 0, 0); // 0x001F0000
-    cmdbuf[1] = size;
-    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[3] = (u32) out;
+	cmdbuf[0] = IPC_MakeHeader(0x1F, 0, 0); // 0x001F0000
+	cmdbuf[1] = size;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[3] = (u32) out;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetSdmcSpeedInfo(Handle serviceHandle, u32* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x20, 0, 0); // 0x00200000
+	cmdbuf[0] = IPC_MakeHeader(0x20, 0, 0); // 0x00200000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out) *out = cmdbuf[2];
+	if(out) *out = cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetNandSpeedInfo(Handle serviceHandle, u32* out)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x21, 0, 0); // 0x00210000
+	cmdbuf[0] = IPC_MakeHeader(0x21, 0, 0); // 0x00210000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(out) *out = cmdbuf[2];
+	if(out) *out = cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetSdmcLog(Handle serviceHandle, void* out, u32 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x22, 1, 2); // 0x00220042
-    cmdbuf[1] = size;
-    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[3] = (u32) out;
+	cmdbuf[0] = IPC_MakeHeader(0x22, 1, 2); // 0x00220042
+	cmdbuf[1] = size;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[3] = (u32) out;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetNandLog(Handle serviceHandle, void* out, u32 size)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x23, 1, 2); // 0x00230042
-    cmdbuf[1] = size;
-    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[3] = (u32) out;
+	cmdbuf[0] = IPC_MakeHeader(0x23, 1, 2); // 0x00230042
+	cmdbuf[1] = size;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[3] = (u32) out;
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ClearSdmcLog(Handle serviceHandle)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x24, 0, 0); // 0x00240000
+	cmdbuf[0] = IPC_MakeHeader(0x24, 0, 0); // 0x00240000
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ClearNandLog(Handle serviceHandle)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x25, 0, 0); // 0x00250000
+	cmdbuf[0] = IPC_MakeHeader(0x25, 0, 0); // 0x00250000
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CardSlotIsInserted(Handle serviceHandle, bool* inserted)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x26, 0, 0); // 0x00260000
+	cmdbuf[0] = IPC_MakeHeader(0x26, 0, 0); // 0x00260000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(inserted) *inserted = (bool)cmdbuf[2];
+	if(inserted) *inserted = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CardSlotPowerOn(Handle serviceHandle, bool* status)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x27, 0, 0); // 0x00270000
+	cmdbuf[0] = IPC_MakeHeader(0x27, 0, 0); // 0x00270000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(status) *status = (bool)cmdbuf[2];
+	if(status) *status = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CardSlotPowerOff(Handle serviceHandle, bool* status)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x28, 0, 0); // 0x00280000
+	cmdbuf[0] = IPC_MakeHeader(0x28, 0, 0); // 0x00280000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(status) *status = (bool)cmdbuf[2];
+	if(status) *status = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CardSlotGetCardIFPowerStatus(Handle serviceHandle, bool* status)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x29, 0, 0); // 0x00290000
+	cmdbuf[0] = IPC_MakeHeader(0x29, 0, 0); // 0x00290000
 
-    if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(status) *status = (bool)cmdbuf[2];
+	if(status) *status = (bool)cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CardNorDirectCommand(Handle serviceHandle, u8 commandId)
@@ -852,7 +852,7 @@ Result FSPXI_CardNorDirectSectorEraseWithoutVerify(Handle serviceHandle, u32 add
 Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, FSPXI_Archive archive)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	u32 *cmdbuf = getThreadCommandBuffer();
 
 	cmdbuf[0] = IPC_MakeHeader(0x33, 2, 0); // 0x00330080
 	cmdbuf[1] = (u32) archive;
@@ -860,74 +860,74 @@ Result FSPXI_GetProductInfo(Handle serviceHandle, FS_ProductInfo* info, FSPXI_Ar
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(info) memcpy(info, &cmdbuf[2], sizeof(FS_ProductInfo));
+	if(info) memcpy(info, &cmdbuf[2], sizeof(FS_ProductInfo));
 
 	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_SetCardSpiBaudrate(Handle serviceHandle, FS_CardSpiBaudRate baudRate)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x34, 1, 0); // 0x00340040
-    cmdbuf[1] = baudRate;
+	cmdbuf[0] = IPC_MakeHeader(0x34, 1, 0); // 0x00340040
+	cmdbuf[1] = baudRate;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_SetCardSpiBusMode(Handle serviceHandle, FS_CardSpiBusMode busMode)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x35, 1, 0); // 0x00350040
-    cmdbuf[1] = busMode;
+	cmdbuf[0] = IPC_MakeHeader(0x35, 1, 0); // 0x00350040
+	cmdbuf[1] = busMode;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_SendInitializeInfoTo9(Handle serviceHandle, u8 unk)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x36, 1, 0); // 0x00360040
-    cmdbuf[1] = unk;
+	cmdbuf[0] = IPC_MakeHeader(0x36, 1, 0); // 0x00360040
+	cmdbuf[1] = unk;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_CreateExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x37, 4, 0);
-    memcpy(&cmdbuf[1], &info, sizeof(FS_ExtSaveDataInfo));
+	cmdbuf[0] = IPC_MakeHeader(0x37, 4, 0);
+	memcpy(&cmdbuf[1], &info, sizeof(FS_ExtSaveDataInfo));
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_DeleteExtSaveData(Handle serviceHandle, FS_ExtSaveDataInfo info)
 {
-    Result ret = 0;
-    u32* cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32* cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x38, 4, 0);
-    memcpy(&cmdbuf[1], &info, sizeof(FS_ExtSaveDataInfo));
+	cmdbuf[0] = IPC_MakeHeader(0x38, 4, 0);
+	memcpy(&cmdbuf[1], &info, sizeof(FS_ExtSaveDataInfo));
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, FS_MediaType mediaType, u32 idSize, bool shared, u8* ids)
@@ -952,10 +952,10 @@ Result FSPXI_EnumerateExtSaveData(Handle serviceHandle, u32* idsWritten, u32 ids
 
 Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaType mediaType, u64 programId, FS_SpecialContentType type)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3A, 4, 0); // 0x003A0100
+	cmdbuf[0] = IPC_MakeHeader(0x3A, 4, 0); // 0x003A0100
 	cmdbuf[1] = mediaType;
 	cmdbuf[2] = (u32) programId;
 	cmdbuf[3] = (u32) (programId >> 32);
@@ -970,15 +970,15 @@ Result FSPXI_GetSpecialContentIndex(Handle serviceHandle, u16* index, FS_MediaTy
 
 Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* header)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3B, 3, 2); // 0x003B00C2
-    cmdbuf[1] = mediaType;
+	cmdbuf[0] = IPC_MakeHeader(0x3B, 3, 2); // 0x003B00C2
+	cmdbuf[1] = mediaType;
 	cmdbuf[2] = (u32) programId;
 	cmdbuf[3] = (u32) (programId >> 32);
-    cmdbuf[4] = IPC_Desc_PXIBuffer(0x378, 0, false);
-    cmdbuf[5] = (u32) header;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(0x378, 0, false);
+	cmdbuf[5] = (u32) header;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -987,16 +987,16 @@ Result FSPXI_GetLegacyRomHeader(Handle serviceHandle, FS_MediaType mediaType, u6
 
 Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u64 programId, void* banner, u8 unk)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3C, 4, 2); // 0x003C0102
-    cmdbuf[1] = mediaType;
+	cmdbuf[0] = IPC_MakeHeader(0x3C, 4, 2); // 0x003C0102
+	cmdbuf[1] = mediaType;
 	cmdbuf[2] = (u32) programId;
 	cmdbuf[3] = (u32) (programId >> 32);
-    cmdbuf[4] = unk;
-    cmdbuf[5] = IPC_Desc_PXIBuffer(0x23c0, 0, false);
-    cmdbuf[6] = (u32) banner;
+	cmdbuf[4] = unk;
+	cmdbuf[5] = IPC_Desc_PXIBuffer(0x23c0, 0, false);
+	cmdbuf[6] = (u32) banner;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1005,11 +1005,11 @@ Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u
 
 Result FSPXI_FormatCardNorDevice(Handle serviceHandle, u32 unk)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3D, 1, 0); // 0x003D0040
-    cmdbuf[1] = unk;
+	cmdbuf[0] = IPC_MakeHeader(0x3D, 1, 0); // 0x003D0040
+	cmdbuf[1] = unk;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1018,10 +1018,10 @@ Result FSPXI_FormatCardNorDevice(Handle serviceHandle, u32 unk)
 
 Result FSPXI_DeleteSdmcRoot(Handle serviceHandle)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3E, 0, 0); // 0x003E0000
+	cmdbuf[0] = IPC_MakeHeader(0x3E, 0, 0); // 0x003E0000
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1030,11 +1030,11 @@ Result FSPXI_DeleteSdmcRoot(Handle serviceHandle)
 
 Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x3F, 1, 0); // 0x003F0000
-    cmdbuf[1] = 0; // Transaction
+	cmdbuf[0] = IPC_MakeHeader(0x3F, 1, 0); // 0x003F0000
+	cmdbuf[1] = 0; // Transaction
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1043,10 +1043,10 @@ Result FSPXI_DeleteAllExtSaveDataOnNand(Handle serviceHandle)
 
 Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x40, 0, 0); // 0x00400000
+	cmdbuf[0] = IPC_MakeHeader(0x40, 0, 0); // 0x00400000
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1055,10 +1055,10 @@ Result FSPXI_InitializeCtrFilesystem(Handle serviceHandle)
 
 Result FSPXI_CreateSeed(Handle serviceHandle)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x41, 0, 0); // 0x00410000
+	cmdbuf[0] = IPC_MakeHeader(0x41, 0, 0); // 0x00410000
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1068,7 +1068,7 @@ Result FSPXI_CreateSeed(Handle serviceHandle)
 Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u16* out, u32 length)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	u32 *cmdbuf = getThreadCommandBuffer();
 
 	cmdbuf[0] = IPC_MakeHeader(0x42, 1, 2); // 0x00420042
 	cmdbuf[1] = length;
@@ -1083,26 +1083,26 @@ Result FSPXI_GetSdmcCtrRootPath(Handle serviceHandle, u16* out, u32 length)
 Result FSPXI_GetArchiveResource(Handle serviceHandle, FS_ArchiveResource* archiveResource, FS_SystemMediaType mediaType)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
-    
+	u32 *cmdbuf = getThreadCommandBuffer();
+	
 	cmdbuf[0] = IPC_MakeHeader(0x43, 1, 0); // 0x00430040
 	cmdbuf[1] = mediaType;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    memcpy(archiveResource, &cmdbuf[2], sizeof(FS_ArchiveResource));
+	memcpy(archiveResource, &cmdbuf[2], sizeof(FS_ArchiveResource));
 
 	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityVerificationSeed* seed)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x44, 0, 2); // 0x00440002
-    cmdbuf[1] = IPC_Desc_PXIBuffer(0x130, 0, false);
-    cmdbuf[2] = (u32)seed;
+	cmdbuf[0] = IPC_MakeHeader(0x44, 0, 2); // 0x00440002
+	cmdbuf[1] = IPC_Desc_PXIBuffer(0x130, 0, false);
+	cmdbuf[2] = (u32)seed;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1111,12 +1111,12 @@ Result FSPXI_ExportIntegrityVerificationSeed(Handle serviceHandle, FS_IntegrityV
 
 Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_IntegrityVerificationSeed* seed)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x45, 0, 2); // 0x00450002
-    cmdbuf[1] = IPC_Desc_PXIBuffer(0x130, 0, true);
-    cmdbuf[2] = (u32)seed;
+	cmdbuf[0] = IPC_MakeHeader(0x45, 0, 2); // 0x00450002
+	cmdbuf[1] = IPC_Desc_PXIBuffer(0x130, 0, true);
+	cmdbuf[2] = (u32)seed;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1125,10 +1125,10 @@ Result FSPXI_ImportIntegrityVerificationSeed(Handle serviceHandle, const FS_Inte
 
 Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_MediaType mediaType, u64 programId, void* banner)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x46, 4, 2); // 0x00460102
+	cmdbuf[0] = IPC_MakeHeader(0x46, 4, 2); // 0x00460102
 	cmdbuf[1] = bannerSize;
 	cmdbuf[2] = mediaType;
 	cmdbuf[3] = (u32) programId;
@@ -1143,13 +1143,13 @@ Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_Med
 
 Result FSPXI_GenerateRandomBytes(Handle serviceHandle, void* buf, u32 size)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x47, 1, 2); // 0x00470042
-    cmdbuf[1] = size;
-    cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[3] = (u32) buf;
+	cmdbuf[0] = IPC_MakeHeader(0x47, 1, 2); // 0x00470042
+	cmdbuf[1] = size;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[3] = (u32) buf;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1158,29 +1158,29 @@ Result FSPXI_GenerateRandomBytes(Handle serviceHandle, void* buf, u32 size)
 
 Result FSPXI_GetFileLastModified(Handle serviceHandle, FSPXI_Archive archive, u64* out, const u16* path, u32 size)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x48, 3, 2); // 0x004800C2
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
-    cmdbuf[3] = size;
-    cmdbuf[4] = IPC_Desc_PXIBuffer(size, 0, true);
-    cmdbuf[5] = (u32) path;
+	cmdbuf[0] = IPC_MakeHeader(0x48, 3, 2); // 0x004800C2
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[3] = size;
+	cmdbuf[4] = IPC_Desc_PXIBuffer(size, 0, true);
+	cmdbuf[5] = (u32) path;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	if (out) *out = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffset, u32 size, void* data)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
-    
-    cmdbuf[0] = IPC_MakeHeader(0x49, 4, 2); // 0x00490102
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+	
+	cmdbuf[0] = IPC_MakeHeader(0x49, 4, 2); // 0x00490102
 	cmdbuf[1] = 0;
 	cmdbuf[2] = (u32) fileOffset;
 	cmdbuf[3] = (u32) (fileOffset >> 32);
@@ -1188,46 +1188,46 @@ Result FSPXI_ReadSpecialFile(Handle serviceHandle, u32* bytesRead, u64 fileOffse
 	cmdbuf[5] = IPC_Desc_PXIBuffer(size, 0, false);
 	cmdbuf[6] = (u32) data;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (bytesRead) *bytesRead = cmdbuf[2];
+	if (bytesRead) *bytesRead = cmdbuf[2];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_GetSpecialFileSize(Handle serviceHandle, u64* fileSize)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x4A, 1, 0); // 0x004A0040
-    cmdbuf[1] = 0; // Must be 0
+	cmdbuf[0] = IPC_MakeHeader(0x4A, 1, 0); // 0x004A0040
+	cmdbuf[1] = 0; // Must be 0
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (fileSize) *fileSize = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
+	if (fileSize) *fileSize = cmdbuf[2] | ((u64) cmdbuf[3] << 32);
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_StartDeviceMoveAsSource(Handle serviceHandle, FS_DeviceMoveContext* context)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x4B, 0, 0); // 0x004B0000
+	cmdbuf[0] = IPC_MakeHeader(0x4B, 0, 0); // 0x004B0000
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if(context) memcpy(context, &cmdbuf[2], sizeof(FS_DeviceMoveContext));
+	if(context) memcpy(context, &cmdbuf[2], sizeof(FS_DeviceMoveContext));
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_DeviceMoveContext context, bool clear)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	u32 *cmdbuf = getThreadCommandBuffer();
 
 	cmdbuf[0] = IPC_MakeHeader(0x4C, 9, 0); // 0x004C0240
 	memcpy(&cmdbuf[1], &context, sizeof(FS_DeviceMoveContext));
@@ -1241,24 +1241,24 @@ Result FSPXI_StartDeviceMoveAsDestination(Handle serviceHandle, FS_DeviceMoveCon
 Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRead, u64 offset, void* readBuffer, u32 readBufferSize, void* hashtable, u32 hashtableSize, u32 unk)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x4D, 7, 4); // 0x004D01C4
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32) (file >> 32);
-    cmdbuf[3] = (u32) offset;
-    cmdbuf[4] = (u32) (offset >> 32);
-    cmdbuf[5] = readBufferSize;
-    cmdbuf[6] = unk;
-    cmdbuf[7] = hashtableSize;
-    cmdbuf[8] = IPC_Desc_PXIBuffer(hashtableSize, 0, false);
-    cmdbuf[9] = (u32) hashtable;
-    cmdbuf[10] = IPC_Desc_PXIBuffer(readBufferSize, 1, false);
-    cmdbuf[11] = (u32) readBuffer;
+	cmdbuf[0] = IPC_MakeHeader(0x4D, 7, 4); // 0x004D01C4
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32) (file >> 32);
+	cmdbuf[3] = (u32) offset;
+	cmdbuf[4] = (u32) (offset >> 32);
+	cmdbuf[5] = readBufferSize;
+	cmdbuf[6] = unk;
+	cmdbuf[7] = hashtableSize;
+	cmdbuf[8] = IPC_Desc_PXIBuffer(hashtableSize, 0, false);
+	cmdbuf[9] = (u32) hashtable;
+	cmdbuf[10] = IPC_Desc_PXIBuffer(readBufferSize, 1, false);
+	cmdbuf[11] = (u32) readBuffer;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (bytesRead) *bytesRead = cmdbuf[2];
+	if (bytesRead) *bytesRead = cmdbuf[2];
 
 	return (Result) cmdbuf[1];
 }
@@ -1266,25 +1266,25 @@ Result FSPXI_ReadFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesRea
 Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWritten, u64 offset, const void* writeBuffer, u32 writeBufferSize, void* hashtable, u32 hashtableSize, u32 unk1, u32 unk2)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x4E, 8, 4); // 0x004E0204
-    cmdbuf[1] = (u32) file;
-    cmdbuf[2] = (u32) (file >> 32);
-    cmdbuf[3] = (u32) offset;
-    cmdbuf[4] = (u32) (offset >> 32);
-    cmdbuf[5] = writeBufferSize;
-    cmdbuf[6] = unk1;
-    cmdbuf[7] = hashtableSize;
-    cmdbuf[8] = unk2;
-    cmdbuf[9] = IPC_Desc_PXIBuffer(hashtableSize, 0, true);
-    cmdbuf[10] = (u32) hashtable;
-    cmdbuf[11] = IPC_Desc_PXIBuffer(writeBufferSize, 1, false);
-    cmdbuf[12] = (u32) writeBuffer;
+	cmdbuf[0] = IPC_MakeHeader(0x4E, 8, 4); // 0x004E0204
+	cmdbuf[1] = (u32) file;
+	cmdbuf[2] = (u32) (file >> 32);
+	cmdbuf[3] = (u32) offset;
+	cmdbuf[4] = (u32) (offset >> 32);
+	cmdbuf[5] = writeBufferSize;
+	cmdbuf[6] = unk1;
+	cmdbuf[7] = hashtableSize;
+	cmdbuf[8] = unk2;
+	cmdbuf[9] = IPC_Desc_PXIBuffer(hashtableSize, 0, true);
+	cmdbuf[10] = (u32) hashtable;
+	cmdbuf[11] = IPC_Desc_PXIBuffer(writeBufferSize, 1, false);
+	cmdbuf[12] = (u32) writeBuffer;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (bytesWritten) *bytesWritten = cmdbuf[2];
+	if (bytesWritten) *bytesWritten = cmdbuf[2];
 
 	return (Result) cmdbuf[1];
 }
@@ -1292,11 +1292,11 @@ Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWr
 Result FSPXI_SetCtrCardLatencyParameter(Handle serviceHandle, u64 latency)
 {
 	Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x4F, 2, 0); // 0x004F0080
-    cmdbuf[1] = (u32) latency;
-    cmdbuf[2] = (u32) (latency >> 32);
+	cmdbuf[0] = IPC_MakeHeader(0x4F, 2, 0); // 0x004F0080
+	cmdbuf[1] = (u32) latency;
+	cmdbuf[2] = (u32) (latency >> 32);
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1305,11 +1305,11 @@ Result FSPXI_SetCtrCardLatencyParameter(Handle serviceHandle, u64 latency)
 
 Result FSPXI_SetPriority(Handle serviceHandle, u32 priority)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x50, 1, 0); // 0x00500040
-    cmdbuf[1] = priority;
+	cmdbuf[0] = IPC_MakeHeader(0x50, 1, 0); // 0x00500040
+	cmdbuf[1] = priority;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1318,11 +1318,11 @@ Result FSPXI_SetPriority(Handle serviceHandle, u32 priority)
 
 Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enable)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x51, 1, 0); // 0x00500040
-    cmdbuf[1] = enable;
+	cmdbuf[0] = IPC_MakeHeader(0x51, 1, 0); // 0x00500040
+	cmdbuf[1] = enable;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1331,31 +1331,31 @@ Result FSPXI_SwitchCleanupInvalidSaveData(Handle serviceHandle, bool enable)
 
 Result FSPXI_EnumerateSystemSaveData(Handle serviceHandle, u32* idsWritten, u32 idsSize, u32* ids)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x54, 1, 2); // 0x00540042
-    cmdbuf[1] = idsSize;
-    cmdbuf[2] = IPC_Desc_PXIBuffer(idsSize, 0, false);
-    cmdbuf[3] = (u32) ids;
+	cmdbuf[0] = IPC_MakeHeader(0x54, 1, 2); // 0x00540042
+	cmdbuf[1] = idsSize;
+	cmdbuf[2] = IPC_Desc_PXIBuffer(idsSize, 0, false);
+	cmdbuf[3] = (u32) ids;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (idsWritten) *idsWritten = cmdbuf[2];
+	if (idsWritten) *idsWritten = cmdbuf[2];
 
 	return (Result) cmdbuf[1];
 }
 
 Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 unk)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x55, 2, 2); // 0x00550082
-    cmdbuf[1] = size;
-    cmdbuf[2] = unk;
-    cmdbuf[3] = IPC_Desc_PXIBuffer(size, 0, false);
-    cmdbuf[4] = (u32) buffer;
+	cmdbuf[0] = IPC_MakeHeader(0x55, 2, 2); // 0x00550082
+	cmdbuf[1] = size;
+	cmdbuf[2] = unk;
+	cmdbuf[3] = IPC_Desc_PXIBuffer(size, 0, false);
+	cmdbuf[4] = (u32) buffer;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
@@ -1364,23 +1364,23 @@ Result FSPXI_ReadNandReport(Handle serviceHandle, void* buffer, u32 size, u32 un
 
 Result FSPXI_Unknown0x56(Handle serviceHandle, u32 out[4], FS_Archive archive, FS_Path path)
 {
-    Result ret = 0;
-    u32 *cmdbuf = getThreadCommandBuffer();
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
 
-    cmdbuf[0] = IPC_MakeHeader(0x56, 4, 2); // 0x00560102
-    cmdbuf[1] = (u32) archive;
-    cmdbuf[2] = (u32) (archive >> 32);
-    cmdbuf[3] = path.type;
-    cmdbuf[4] = path.size;
-    cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
-    cmdbuf[6] = (u32)path.data;
+	cmdbuf[0] = IPC_MakeHeader(0x56, 4, 2); // 0x00560102
+	cmdbuf[1] = (u32) archive;
+	cmdbuf[2] = (u32) (archive >> 32);
+	cmdbuf[3] = path.type;
+	cmdbuf[4] = path.size;
+	cmdbuf[5] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[6] = (u32)path.data;
 
-    if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
+	if (R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    out[0] = cmdbuf[2];
-    out[1] = cmdbuf[3];
-    out[2] = cmdbuf[4];
-    out[3] = cmdbuf[5];
+	out[0] = cmdbuf[2];
+	out[1] = cmdbuf[3];
+	out[2] = cmdbuf[4];
+	out[3] = cmdbuf[5];
 
-    return (Result) cmdbuf[1];
+	return (Result) cmdbuf[1];
 }

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -361,7 +361,7 @@ Result FSPXI_OpenArchive(Handle serviceHandle, FSPXI_Archive* archive, FS_Archiv
     return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, FS_Path path)
+Result FSPXI_HasFile(Handle serviceHandle, FSPXI_Archive archive, bool* out, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -376,12 +376,12 @@ Result FSPXI_Unknown0x13(Handle serviceHandle, FSPXI_Archive archive, u8* out, F
 
     if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = (u8)cmdbuf[2];
+    if (out) *out = (bool)cmdbuf[2];
 
     return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, FS_Path path)
+Result FSPXI_HasDirectory(Handle serviceHandle, FSPXI_Archive archive, bool* out, FS_Path path)
 {
     Result ret = 0;
     u32* cmdbuf = getThreadCommandBuffer();
@@ -396,7 +396,7 @@ Result FSPXI_Unknown0x14(Handle serviceHandle, FSPXI_Archive archive, u32* out, 
 
     if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 
-    if (out) *out = (u8)cmdbuf[2];
+    if (out) *out = (bool)cmdbuf[2];
 
     return (Result) cmdbuf[1];
 }
@@ -1003,7 +1003,7 @@ Result FSPXI_GetLegacyBannerData(Handle serviceHandle, FS_MediaType mediaType, u
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x3D(Handle serviceHandle, u32 unk)
+Result FSPXI_FormatCardNorDevice(Handle serviceHandle, u32 unk)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1141,7 +1141,7 @@ Result FSPXI_GetLegacySubBannerData(Handle serviceHandle, u32 bannerSize, FS_Med
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x47(Handle serviceHandle, void* buf, u32 size)
+Result FSPXI_GenerateRandomBytes(Handle serviceHandle, void* buf, u32 size)
 {
     Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
@@ -1289,14 +1289,14 @@ Result FSPXI_WriteFileSHA256(Handle serviceHandle, FSPXI_File file, u32* bytesWr
 	return (Result) cmdbuf[1];
 }
 
-Result FSPXI_Unknown0x4F(Handle serviceHandle, u64 unk)
+Result FSPXI_SetCtrCardLatencyParameter(Handle serviceHandle, u64 latency)
 {
 	Result ret = 0;
     u32 *cmdbuf = getThreadCommandBuffer();
 
     cmdbuf[0] = IPC_MakeHeader(0x4F, 2, 0); // 0x004F0080
-    cmdbuf[1] = (u32) unk;
-    cmdbuf[2] = (u32) (unk >> 32);
+    cmdbuf[1] = (u32) latency;
+    cmdbuf[2] = (u32) (latency >> 32);
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 


### PR DESCRIPTION
This adds interfaces for the FSPXI services. I modeled the initialization interface off of AMPXI, which has the optional handle parameter.
Because there are four FSPXI services, all with the same API, I had a little bit of trouble deciding how best to present them. I settled on the current macro-based declarations, as it enables easy addition of commands, were Nintendo to ever add any more commands and stays the closest to the way the rest of ctrulib handles separate services. The three other options I thought of while writing this were splitting them into separate files for each service, which seems like excessive code duplication; explicit declaration of all service methods, which I have no reason against, it just wasn't the option I went with in the end; and passing in a service handle to the commands, which is out of style compared to all the rest of the service definitions. Note that I had to go with explicit definition of the service methods in the source file; I would have done it with a macro there, but it isn't easily possible to parse out the argument names only from a macro to pass to the real implementation.
I included several commands with unknown usage. Most of these commands are actually used by FS, with the only one I included that is not being 0x3D. I would have left all of them out had most not been used, and leaving out only 0x3D didn't seem like a useful omission.
Some commands have a "transaction ID" documented in 3dbrew. I did the same here as the FS interface does: I always set them to 0.
There are a couple commands with unknown parameters. I am currently attempting to find what they are used for. As I am not currently certain as to whether they are important or not, I left them in the command signatures.

As for why these are necessary: An eventual FS re-implementation in Luma will need these commands. My personal use case is far simpler than that, though: it was found that through Luma's extended SVCs, it's possible to copy and use a PXIFS handle, through which operations can be done on GBA VC saves, which are inaccessible through any other interface.