### PR TITLE
Fix srv/srvpm sysver checks

### DIFF
--- a/libctru/source/services/srvpm.c
+++ b/libctru/source/services/srvpm.c
@@ -8,7 +8,7 @@
 #include <3ds/ipc.h>
 #include <3ds/os.h>
 
-#define IS_PRE_7X (osGetFirmVersion() < SYSTEM_VERSION(2, 39, 4))
+#define IS_PRE_7X (GET_VERSION_MINOR(osGetFirmVersion()) < 39)
 
 static Handle srvPmHandle;
 static int srvPmRefCount;

--- a/libctru/source/srv.c
+++ b/libctru/source/srv.c
@@ -31,7 +31,7 @@ Result srvInit(void)
 
 	if (AtomicPostIncrement(&srvRefCount)) return 0;
 
-	if(osGetFirmVersion() < SYSTEM_VERSION(2, 39, 4) && *srvPmGetSessionHandle() != 0)
+	if(GET_VERSION_MINOR(osGetKernelVersion()) < 39 && *srvPmGetSessionHandle() != 0)
 		rc = svcDuplicateHandle(&srvHandle, *srvPmGetSessionHandle()); // Prior to system version 7.0 srv:pm was a superset of srv:
 	else
 		rc = svcConnectToPort(&srvHandle, "srv:");


### PR DESCRIPTION
- Kernel major version is 3 on SAFE_FIRM
- osGetFirmVersion() is not always equal to osGetKernelVersion()