### PR TITLE
Make initSystem and __ctru_exit weak. Use asm macros

### DIFF
--- a/libctru/Makefile
+++ b/libctru/Makefile
@@ -54,7 +54,7 @@ CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 
-ASFLAGS	:=	-g $(ARCH)
+ASFLAGS	:=	-g $(ARCH) $(INCLUDE)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/libctru/include/3ds/asminc.h
+++ b/libctru/include/3ds/asminc.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#if !__ASSEMBLER__
+    #error This header file is only for use in assembly files!
+#endif // !__ASSEMBLER__
+
+.macro BEGIN_ASM_FUNC name, linkage=global, section=text
+    .section        .\section\().\name, "ax", %progbits
+    .align          2
+    .\linkage       \name
+    .type           \name, %function
+    .func           \name
+    .cfi_sections   .debug_frame
+    .cfi_startproc
+    \name:
+.endm
+
+.macro END_ASM_FUNC
+    .cfi_endproc
+    .endfunc
+.endm

--- a/libctru/source/svc.s
+++ b/libctru/source/svc.s
@@ -1,17 +1,14 @@
+#include <3ds/asminc.h>
+
 .arm
 .align 4
 
 .macro SVC_BEGIN name
-	.section .text.\name, "ax", %progbits
-	.global \name
-	.type \name, %function
-	.align 2
-	.cfi_startproc
-\name:
+	BEGIN_ASM_FUNC \name
 .endm
 
 .macro SVC_END
-	.cfi_endproc
+	END_ASM_FUNC
 .endm
 
 SVC_BEGIN svcControlMemory

--- a/libctru/source/system/readtp.s
+++ b/libctru/source/system/readtp.s
@@ -1,9 +1,9 @@
+#include <3ds/asminc.h>
+
 .arm
-.section .text.__aeabi_read_tp, "ax", %progbits
-.global __aeabi_read_tp
-.type __aeabi_read_tp, %function
-.align 2
-__aeabi_read_tp:
+
+BEGIN_ASM_FUNC __aeabi_read_tp
 	mrc p15, 0, r0, c13, c0, 3
 	ldr r0, [r0, #0xC] @ Read ThreadVars.tls_tp
 	bx lr
+END_ASM_FUNC

--- a/libctru/source/system/stack_adjust.s
+++ b/libctru/source/system/stack_adjust.s
@@ -1,11 +1,8 @@
+#include <3ds/asminc.h>
 
 	.arm
-	.align 2
 
-	.global	initSystem
-	.type	initSystem,	%function
-
-initSystem:
+BEGIN_ASM_FUNC initSystem, weak
 	ldr	r2, =saved_stack
 	str	sp, [r2]
 	str	lr, [r2,#4]
@@ -29,18 +26,16 @@ initSystem:
 	ldr	r2, =saved_stack
 	ldr	lr, [r2,#4]
  	bx	lr
+END_ASM_FUNC
 
-
-	.global	__ctru_exit
-	.type	__ctru_exit,	%function
-
-__ctru_exit:
+BEGIN_ASM_FUNC __ctru_exit, weak
 	bl	__libc_fini_array
 	bl	__appExit
 
 	ldr	r2, =saved_stack
 	ldr	sp, [r2]
 	b	__libctru_exit
+END_ASM_FUNC
 
 	.data
 	.align 2


### PR DESCRIPTION
We're using these fuctions as if they were weak so let's make them weak