### PR TITLE
GPU HW init, etc.

### DIFF
--- a/libctru/include/3ds/services/gspgpu.h
+++ b/libctru/include/3ds/services/gspgpu.h
@@ -144,8 +144,11 @@ Result GSPGPU_ReleaseRight(void);
  */
 Result GSPGPU_ImportDisplayCaptureInfo(GSPGPU_CaptureInfo*captureinfo);
 
-/// Sames the VRAM sys area.
+/// Saves the VRAM sys area.
 Result GSPGPU_SaveVramSysArea(void);
+
+/// Resets the GPU
+Result GSPGPU_ResetGpuCore(void);
 
 /// Restores the VRAM sys area.
 Result GSPGPU_RestoreVramSysArea(void);

--- a/libctru/source/services/gspgpu.c
+++ b/libctru/source/services/gspgpu.c
@@ -430,6 +430,17 @@ Result GSPGPU_RestoreVramSysArea(void)
 	return cmdbuf[1];
 }
 
+Result GSPGPU_ResetGpuCore(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+	cmdbuf[0]=IPC_MakeHeader(0x1B,0,0); // 0x001B0000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(gspGpuHandle)))return ret;
+
+	return cmdbuf[1];
+}
+
 Result GSPGPU_SetLedForceOff(bool disable)
 {
 	u32 *cmdbuf = getThreadCommandBuffer();


### PR DESCRIPTION
GSP assumes its first user will initialize the GPU (GSP only initializes the basic engines, leaving some blocks without clock enabled). This fixes it

See also: https://gist.github.com/TuxSH/40a861448be397347090975ac65a633b