### PR TITLE
Add mtime to stat

### DIFF
--- a/libctru/source/archive_dev.c
+++ b/libctru/source/archive_dev.c
@@ -839,6 +839,13 @@ archive_stat(struct _reent *r,
     archive_file_t tmpfd = { .fd = fd };
     rc = archive_fstat(r, &tmpfd, st);
     FSFILE_Close(fd);
+    if (R_SUCCEEDED(rc))
+    {
+      u64 mtime;
+      rc = archive_getmtime(file, &mtime);
+      st->st_mtim.tv_sec = mtime;
+      st->st_mtim.tv_nsec = 0;
+    }
 
     return rc;
   }


### PR DESCRIPTION
I would add this to fstat, but archive_getmtime requires a path. Not sure if there's a way around that.