### PR TITLE
Fixes for Mii struct and FRD_GetFriendKeyList

### DIFF
--- a/libctru/include/3ds/mii.h
+++ b/libctru/include/3ds/mii.h
@@ -170,3 +170,11 @@ typedef struct
 
 	u16 author_name[10];    ///< Name of Mii's author (Encoded using UTF16)
 } CTR_PACKED MiiData;
+
+/// Mii CFLStoreData (CTR Face Library Store Data) structure
+typedef struct
+{
+	MiiData miiData; ///< Common shared Mii data structure.
+	u8 pad[2]; ///< Padding (usually left as zeros)
+	u16 crc16; ///< CRC16 over the previous 0x5E of data
+} CFLStoreData;

--- a/libctru/include/3ds/services/act.h
+++ b/libctru/include/3ds/services/act.h
@@ -150,14 +150,6 @@ typedef struct
 
 #pragma pack(push, 1)
 
-/// Mii CFLStoreData (CTR Face Library Store Data) structure
-typedef struct
-{
-	MiiData miiData;
-	u8 pad[2];
-	u16 crc16;
-} CFLStoreData;
-
 /// Birth date structure
 typedef struct
 {

--- a/libctru/include/3ds/services/frd.h
+++ b/libctru/include/3ds/services/frd.h
@@ -92,22 +92,14 @@ typedef struct
 	u8 pad;
 } FriendPresence;
 
-/// Friend Mii data
-typedef struct
-{
-	bool profanityFlag; ///< Whether or not the Mii contains profanity.
-	u8 characterSet; ///< The character set for text data.
-	bool dirtyFlag; ///< Whether or not the Mii is marked as "dirty" (needs to be uploaded to the server).
-	u8 pad;
-	MiiData mii; ///< The actual Mii data.
-} FriendMii;
-
 /// Friend playing game structure
 typedef struct
 {
 	GameKey game; ///< Game key of the game.
 	FriendGameModeDescription gameModeDescription;
 } FriendPlayingGame;
+
+typedef CFLStoreData FriendMii;
 
 /// Friend info structure
 typedef struct
@@ -420,9 +412,9 @@ Result FRD_GetMyPassword(char *password, u32 bufsize);
  * @param friendKeyList Pointer to write the friend key list to.
  * @param num Stores the number of friend keys obtained.
  * @param offset The index of the friend key to start with.
- * @param size Size of the friend key list. (FRIEND_LIST_SIZE)
+ * @param count Number of friend keys to retrieve. Max: FRIEND_LIST_SIZE
  */
-Result FRD_GetFriendKeyList(FriendKey *friendKeyList, u32 *num, u32 offset, u32 size);
+Result FRD_GetFriendKeyList(FriendKey *friendKeyList, u32 *num, u32 offset, u32 count);
 
 /**
  * @brief Gets friend presence data for the current user's friends.

--- a/libctru/source/services/frd.c
+++ b/libctru/source/services/frd.c
@@ -285,7 +285,7 @@ Result FRD_GetMyPassword(char *password, u32 bufsize)
 	return (Result)cmdbuf[1];
 }
 
-Result FRD_GetFriendKeyList(FriendKey *friendKeyList, u32 *num, u32 offset, u32 size)
+Result FRD_GetFriendKeyList(FriendKey *friendKeyList, u32 *num, u32 offset, u32 count)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -296,9 +296,9 @@ Result FRD_GetFriendKeyList(FriendKey *friendKeyList, u32 *num, u32 offset, u32 
 
 	cmdbuf[0] = IPC_MakeHeader(0x11,2,0); // 0x110080
 	cmdbuf[1] = offset;
-	cmdbuf[2] = size;
+	cmdbuf[2] = count;
 
-	staticbufs[0] = IPC_Desc_StaticBuffer(size, 0);
+	staticbufs[0] = IPC_Desc_StaticBuffer(count * sizeof(FriendKey), 0);
 	staticbufs[1] = (u32)friendKeyList;
 
 	ret = svcSendSyncRequest(frdHandle);


### PR DESCRIPTION
[This commit](https://github.com/devkitPro/libctru/commit/03cade8c4507c2c42c72aed6920225ec78cc330f) introduced a regression which caused users to see invalid data when accessing the `FriendMii` struct. This was caused by the presence of extra fields at the beginning of the struct that are not actually part of the data returned by the friends sysmodule.

The changes made here:
- Move `CFLStoreData` from `act.h` to `mii.h` as it turns out this struct is shared across many titles and sysmodules;
- Define `FriendMii` as `CFLStoreData` so that commands taking in `FriendMii` or returning structs that contain Mii data can be accessed properly.

In addition, through my own testing I have discovered that `FRD_GetFriendKeyList` was passing invalid static buffer descriptors, causing a crash whenever this command was used, so I have corrected this as well.