### PR TITLE
Enable passing const u32* to DVLB_ParseFile()

### DIFF
--- a/libctru/include/3ds/gpu/shbin.h
+++ b/libctru/include/3ds/gpu/shbin.h
@@ -42,10 +42,10 @@ typedef enum
 
 /// DVLP data.
 typedef struct{
-	u32 codeSize;     ///< Code size.
-	u32* codeData;    ///< Code data.
-	u32 opdescSize;   ///< Operand description size.
-	u32* opcdescData; ///< Operand description data.
+	u32 codeSize;        ///< Code size.
+	const u32* codeData; ///< Code data.
+	u32 opdescSize;      ///< Operand description size.
+	u32* opcdescData;    ///< Operand description data.
 }DVLP_s;
 
 /// DVLE constant entry data.
@@ -107,7 +107,7 @@ typedef struct{
  * @param shbinSize Shader binary size.
  * @return The parsed shader binary.
  */
-DVLB_s* DVLB_ParseFile(u32* shbinData, u32 shbinSize);
+DVLB_s* DVLB_ParseFile(const u32* shbinData, u32 shbinSize);
 
 /**
  * @brief Frees shader binary data.

--- a/libctru/source/gpu/shaderProgram.c
+++ b/libctru/source/gpu/shaderProgram.c
@@ -6,7 +6,7 @@
 #include <3ds/gpu/shaderProgram.h>
 
 static void GPU_SetShaderOutmap(const u32 outmapData[8]);
-static void GPU_SendShaderCode(GPU_SHADER_TYPE type, u32* data, u16 offset, u16 length);
+static void GPU_SendShaderCode(GPU_SHADER_TYPE type, const u32* data, u16 offset, u16 length);
 static void GPU_SendOperandDescriptors(GPU_SHADER_TYPE type, u32* data, u16 offset, u16 length);
 
 Result shaderInstanceInit(shaderInstance_s* si, DVLE_s* dvle)
@@ -348,7 +348,7 @@ void GPU_SetShaderOutmap(const u32 outmapData[8])
 	GPUCMD_AddIncrementalWrites(GPUREG_SH_OUTMAP_TOTAL, outmapData, 8);
 }
 
-void GPU_SendShaderCode(GPU_SHADER_TYPE type, u32* data, u16 offset, u16 length)
+void GPU_SendShaderCode(GPU_SHADER_TYPE type, const u32* data, u16 offset, u16 length)
 {
 	if(!data)return;
 

--- a/libctru/source/gpu/shbin.c
+++ b/libctru/source/gpu/shbin.c
@@ -9,7 +9,7 @@
 #include <3ds/gpu/shbin.h>
 
 //please don't feed this an invalid SHBIN
-DVLB_s* DVLB_ParseFile(u32* shbinData, u32 shbinSize)
+DVLB_s* DVLB_ParseFile(const u32* shbinData, u32 shbinSize)
 {
 	if(!shbinData)return NULL;
 	DVLB_s* ret=malloc(sizeof(DVLB_s));
@@ -21,7 +21,7 @@ DVLB_s* DVLB_ParseFile(u32* shbinData, u32 shbinSize)
 	if(!ret->DVLE)goto clean1;
 
 	//parse DVLP
-	u32* dvlpData=&shbinData[2+ret->numDVLE];
+	const u32* dvlpData=&shbinData[2+ret->numDVLE];
 	ret->DVLP.codeSize=dvlpData[3];
 	ret->DVLP.codeData=&dvlpData[dvlpData[2]/4];
 	ret->DVLP.opdescSize=dvlpData[5];
@@ -33,7 +33,7 @@ DVLB_s* DVLB_ParseFile(u32* shbinData, u32 shbinSize)
 	for(i=0;i<ret->numDVLE;i++)
 	{
 		DVLE_s* dvle=&ret->DVLE[i];
-		u32* dvleData=&shbinData[shbinData[2+i]/4];
+		const u32* dvleData=&shbinData[shbinData[2+i]/4];
 
 		dvle->dvlp=&ret->DVLP;
 


### PR DESCRIPTION
Consists of the bare minimum changes to allow passing a `const u32*` to `DVLB_ParseFile()`. Compiles and runs properly, though I'm not an expert with the PICA200 so I wouldn't be too surprised if this has some kind of subtle breakage somewhere.