### PR TITLE
Add link3dsDisconnectFromHost()

### DIFF
--- a/libctru/include/3ds/3dslink.h
+++ b/libctru/include/3ds/3dslink.h
@@ -16,10 +16,12 @@ extern struct in_addr __3dslink_host;
 
 /**
  * @brief Connects to the 3dslink host, setting up an output stream.
- * @param[in] redirStdout Whether to redirect stdout to nxlink output.
- * @param[in] redirStderr Whether to redirect stderr to nxlink output.
+ * @param[in] redirStdout Whether to redirect stdout to 3dslink output.
+ * @param[in] redirStderr Whether to redirect stderr to 3dslink output.
  * @return Socket fd on success, negative number on failure.
- * @note The socket should be closed with close() during application cleanup.
+ * @note SOC must be initialized (\ref socInit or \ref socInitMulti) before calling this function.
+ * @note The connection should be closed with link3dsDisconnectFromHost() during application cleanup.
+ * @note Do not call \ref socExit until link3dsDisconnectFromHost() has been called.
  */
 int link3dsConnectToHost(bool redirStdout, bool redirStderr);
 
@@ -32,3 +34,9 @@ static inline int link3dsStdio(void) {
 static inline int link3dsStdioForDebug(void) {
     return link3dsConnectToHost(false, true);
 }
+
+/**
+  * @brief Disconnects from the 3dslink host.
+  * @note Do not call \ref socExit until this has been called.
+  */
+void link3dsDisconnectFromHost();

--- a/libctru/source/3dslink.c
+++ b/libctru/source/3dslink.c
@@ -46,3 +46,10 @@ int link3dsConnectToHost(bool redirStdout, bool redirStderr)
 
 	return sock;
 }
+
+void link3dsDisconnectFromHost()
+{
+	close(sock);
+	close(STDOUT_FILENO);
+	close(STDERR_FILENO);
+}


### PR DESCRIPTION
This fixes a potential crash when linking stdout/stderr to 3dslink output.

Even when closing the socket as instructed in the docstring, a crash can occur.

In socExit, the `soc` device is removed from `devoptab_list`, which invalidates the `device` in the file descriptor for the socket/stderr/stdout. During an exit routine, newlib calls into `cleanup_stdio`, which closes the std streams.
This creates the case where `handles[STD_OUT]` and `handles[STD_ERR]` are valid but the corresponding `devoptab` entry is no longer alive. Hence, close() on stdio/err causes a segfault.

The solution is to close both stdout and stderr along with the socket when disconnecting from the 3dslink host. For convenience, this has been placed into a wrapper, `link3dsDisconnectFromHost`.